### PR TITLE
building out TurnLogger contract managed by an Admin client

### DIFF
--- a/contracts/admin/abi/admin_abi.json
+++ b/contracts/admin/abi/admin_abi.json
@@ -1,0 +1,51 @@
+[
+    {
+        "data": [
+            {
+                "name": "old_admin_address",
+                "type": "felt"
+            },
+            {
+                "name": "new_address",
+                "type": "felt"
+            }
+        ],
+        "keys": [],
+        "name": "UpdatedAdminAddress",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "name": "admin_address",
+                "type": "felt"
+            }
+        ],
+        "name": "constructor",
+        "outputs": [],
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "Admin_get_admin_address",
+        "outputs": [
+            {
+                "name": "admin_address",
+                "type": "felt"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "new_address",
+                "type": "felt"
+            }
+        ],
+        "name": "Admin_set_admin_address",
+        "outputs": [],
+        "type": "function"
+    }
+]

--- a/contracts/admin/admin.cairo
+++ b/contracts/admin/admin.cairo
@@ -1,0 +1,77 @@
+%lang starknet
+#Give the same functionality as onlyOwner() in a solidity contract. Specifies which Account is admin 
+#Manage proxy upgrades to depployer contracts (so whatever we use to interact with message registry 
+
+# Permissioned calls will be 
+# writing over chat again at the end of each round to encourage light chat persisence (this could be done automatically by checking clock)
+# 
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+#
+# Storage
+#
+
+@storage_var
+func Admin_admin_address_storage() -> (admin_address : felt):
+end
+
+#
+# Events
+#
+@event
+func UpdatedAdminAddress(old_admin_address : felt, new_address : felt):
+end
+
+
+#
+# Constructor
+#
+@constructor
+func constructor{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(admin_address : felt):
+    let (existing_admin_address) = Admin_admin_address_storage.read()
+    with_attr error_message("Admin: Admin address is already initialized"):
+        assert existing_admin_address = 0
+    end
+
+    Admin_admin_address_storage.write(admin_address)
+    return ()
+end
+
+#
+# Getters
+#
+@view
+func Admin_get_admin_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        ) -> (admin_address : felt):
+    let (admin_address) = Admin_admin_address_storage.read()
+    return (admin_address)
+end
+
+#
+# Setters
+#
+@external
+func Admin_set_admin_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        new_address : felt):
+    Admin_only_admin()
+    let (old_admin_address) = Admin_admin_address_storage.read()
+    Admin_admin_address_storage.write(new_address)
+    UpdatedAdminAddress.emit(old_admin_address, new_address)
+    return ()
+end
+
+#
+# Guards
+#
+
+func Admin_only_admin{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    let (caller_address) = get_caller_address()
+    let (admin_address) = Admin_admin_address_storage.read()
+    with_attr error_message("Admin: Called by non-admin contract"):
+        assert caller_address = admin_address
+    end
+    return ()
+end

--- a/contracts/admin/library.cairo
+++ b/contracts/admin/library.cairo
@@ -1,3 +1,0 @@
-#Give the same functionality as onlyOwner() in a solidity contract.
-#Manage proxy upgrades to a contract and any 
-

--- a/contracts/admin/output/admin_compiled.json
+++ b/contracts/admin/output/admin_compiled.json
@@ -3,18 +3,22 @@
         {
             "data": [
                 {
-                    "name": "contract_address",
+                    "name": "old_admin_address",
+                    "type": "felt"
+                },
+                {
+                    "name": "new_address",
                     "type": "felt"
                 }
             ],
             "keys": [],
-            "name": "turn_logger_contract_deployed",
+            "name": "UpdatedAdminAddress",
             "type": "event"
         },
         {
             "inputs": [
                 {
-                    "name": "turn_logger_class_hash_",
+                    "name": "admin_address",
                     "type": "felt"
                 }
             ],
@@ -23,13 +27,25 @@
             "type": "constructor"
         },
         {
-            "inputs": [
+            "inputs": [],
+            "name": "Admin_get_admin_address",
+            "outputs": [
                 {
-                    "name": "turn_logger_address",
+                    "name": "admin_address",
                     "type": "felt"
                 }
             ],
-            "name": "deploy_new_game",
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "new_address",
+                    "type": "felt"
+                }
+            ],
+            "name": "Admin_set_admin_address",
             "outputs": [],
             "type": "function"
         }
@@ -37,20 +53,60 @@
     "entry_points_by_type": {
         "CONSTRUCTOR": [
             {
-                "offset": "0x8c",
+                "offset": "0x69",
                 "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
             }
         ],
         "EXTERNAL": [
             {
-                "offset": "0xc5",
-                "selector": "0x836f0191f38692b29488890228b54a1d221c344a4a3624a20045883227507e"
+                "offset": "0x8a",
+                "selector": "0x1669870ae86d3cd5c5156f49705b76bdd68014cdad15d1e94242af27bf3fea2"
+            },
+            {
+                "offset": "0xb0",
+                "selector": "0x27ca632f4abd91de683a83456bb97dd923b7483baae6a0d77185ec312ff7b89"
             }
         ],
         "L1_HANDLER": []
     },
     "program": {
-        "attributes": [],
+        "attributes": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__",
+                    "__main__.constructor"
+                ],
+                "end_pc": 98,
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 23
+                    },
+                    "reference_ids": {}
+                },
+                "name": "error_message",
+                "start_pc": 96,
+                "value": "Admin: Admin address is already initialized"
+            },
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.Admin_only_admin"
+                ],
+                "end_pc": 203,
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 29
+                    },
+                    "reference_ids": {}
+                },
+                "name": "error_message",
+                "start_pc": 202,
+                "value": "Admin: Called by non-admin contract"
+            }
+        ],
         "builtins": [
             "pedersen",
             "range_check"
@@ -59,25 +115,12 @@
             "0x40780017fff7fff",
             "0x1",
             "0x208b7fff7fff7ffe",
-            "0x208b7fff7fff7ffe",
-            "0x1104800180018000",
-            "0x800000000000011000000000000000000000000000000000000000000000000",
-            "0x482480017ffe8000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffff",
-            "0x208b7fff7fff7ffe",
             "0x480680017fff8000",
-            "0x4465706c6f79",
-            "0x400280007ff97fff",
-            "0x400380017ff97ffa",
-            "0x400380027ff97ffb",
-            "0x400380037ff97ffc",
-            "0x400380047ff97ffd",
-            "0x480680017fff8000",
-            "0x0",
-            "0x400280057ff97fff",
-            "0x482680017ff98000",
-            "0x9",
-            "0x480280067ff98000",
+            "0x47657443616c6c657241646472657373",
+            "0x400280007ffd7fff",
+            "0x482680017ffd8000",
+            "0x2",
+            "0x480280017ffd8000",
             "0x208b7fff7fff7ffe",
             "0x480680017fff8000",
             "0x53746f7261676552656164",
@@ -108,7 +151,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x480680017fff8000",
-            "0x5e334153147e75f3f416139b5109d1179cb56fef6a4ecb4c4cbc92a7c37b70",
+            "0xd658d09762405248737fa408e40de0a21378c8a80024eeb81d75b3cca025d0",
             "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
@@ -135,66 +178,44 @@
             "0x48127ff67fff8000",
             "0x48127ff67fff8000",
             "0x208b7fff7fff7ffe",
-            "0x480a7ffc7fff8000",
-            "0x480a7ffd7fff8000",
-            "0x480680017fff8000",
-            "0x2df35b07c81f50cbfa94409be8ca0cbecf3795093edbb1c00fc45ff06446f23",
-            "0x208b7fff7fff7ffe",
-            "0x480a7ffc7fff8000",
-            "0x480a7ffd7fff8000",
-            "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
-            "0x480a7ffb7fff8000",
-            "0x48127ffe7fff8000",
-            "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbe",
-            "0x48127ffe7fff8000",
-            "0x48127ff57fff8000",
-            "0x48127ff57fff8000",
-            "0x48127ffc7fff8000",
-            "0x208b7fff7fff7ffe",
-            "0x480a7ffb7fff8000",
-            "0x480a7ffc7fff8000",
-            "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
-            "0x480a7ffa7fff8000",
-            "0x48127ffe7fff8000",
-            "0x480a7ffd7fff8000",
-            "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb8",
-            "0x48127ff67fff8000",
-            "0x48127ff67fff8000",
-            "0x208b7fff7fff7ffe",
             "0x40780017fff7fff",
             "0x2",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff92",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbd",
             "0x40137fff7fff8000",
             "0x480680017fff8000",
-            "0x324742c36caad354b977e649585ce930a38015f62bfd89088992e34dc3560d",
+            "0x1fbbbae5cec2aa46d0362f8655a7009e419b4c6cd0fe062d36d22ed462993db",
             "0x4002800080007fff",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8c",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb7",
             "0x40137fff7fff8001",
-            "0x4003800080017ffd",
+            "0x4003800080017ffc",
+            "0x4003800180017ffd",
             "0x4826800180018000",
-            "0x1",
-            "0x480a7ffb7fff8000",
+            "0x2",
+            "0x480a7ffa7fff8000",
             "0x480680017fff8000",
             "0x1",
             "0x480a80007fff8000",
             "0x4828800180007ffc",
             "0x480a80017fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffa7",
-            "0x480a7ffc7fff8000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc4",
+            "0x480a7ffb7fff8000",
             "0x208b7fff7fff7ffe",
             "0x480a7ffa7fff8000",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcc",
+            "0x400680017fff7fff",
+            "0x0",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd9",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd1",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
             "0x1",
@@ -204,7 +225,7 @@
             "0x480280027ffb8000",
             "0x480280007ffd8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff3",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffec",
             "0x40780017fff7fff",
             "0x1",
             "0x48127ffc7fff8000",
@@ -214,43 +235,57 @@
             "0x0",
             "0x48127ffb7fff8000",
             "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffac",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x4003800080007ffc",
+            "0x4826800180008000",
+            "0x1",
+            "0x480a7ffd7fff8000",
+            "0x4828800080007ffe",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x402b7ffd7ffc7ffd",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+            "0x48127ff47fff8000",
+            "0x48127ff47fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
             "0x480a7ffa7fff8000",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff96",
-            "0x48127ffc7fff8000",
-            "0x48127ffc7fff8000",
-            "0x48127ffc7fff8000",
+            "0x26",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffaf",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8c",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff5c",
-            "0x482480017fff8000",
-            "0x800000000000011000000000000000000000000000000000000000000000000",
-            "0x48127ff57fff8000",
-            "0x48127ff77fff8000",
-            "0x48127fdf7fff8000",
-            "0x480680017fff8000",
-            "0x1",
-            "0x48127ffb7fff8000",
-            "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff57",
-            "0x48127ffe7fff8000",
-            "0x48127fea7fff8000",
-            "0x48127fea7fff8000",
-            "0x482480017fd38000",
-            "0x1",
-            "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8a",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff93",
             "0x48127ffd7fff8000",
             "0x48127ffe7fff8000",
             "0x48127fe77fff8000",
+            "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffaf",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff99",
             "0x48127ffe7fff8000",
-            "0x48127fe47fff8000",
+            "0x48127fe37fff8000",
             "0x48127ffd7fff8000",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
@@ -261,7 +296,7 @@
             "0x480280027ffb8000",
             "0x480280007ffd8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd3",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe3",
             "0x40780017fff7fff",
             "0x1",
             "0x48127ffc7fff8000",
@@ -270,32 +305,51 @@
             "0x480680017fff8000",
             "0x0",
             "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff41",
+            "0x48127ffe7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff62",
+            "0x40127fff7fff7fe8",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
             "0x208b7fff7fff7ffe"
         ],
         "debug_info": {
             "file_contents": {
                 "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo": "assert [cast(fp + (-4), felt*)] = __calldata_actual_size\n",
-                "autogen/starknet/arg_processor/26f15a9c5452d70e4cc375617f10b6116f9f34527dec544e7a83bf3f2d0d94a6.cairo": "assert [__calldata_ptr] = contract_address\nlet __calldata_ptr = __calldata_ptr + 1\n",
-                "autogen/starknet/arg_processor/37588e1cf2f26f9b7f01bf8c3fd7176010fcc9855ee3cf16012c7824c2e7a569.cairo": "let __calldata_arg_turn_logger_class_hash_ = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/arg_processor/20300ea0c4e496287067a70785a958f9af3a8d44eb9596532186296dbbb6ae49.cairo": "assert [__calldata_ptr] = new_address\nlet __calldata_ptr = __calldata_ptr + 1\n",
                 "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo": "let __calldata_actual_size =  __calldata_ptr - cast([cast(fp + (-3), felt**)], felt*)\n",
-                "autogen/starknet/arg_processor/88f1edfceab034fcb920964e151fec1deaca60c9f795967e361683ce28253d8b.cairo": "let __calldata_arg_turn_logger_address = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
-                "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
-                "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
-                "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/arg_processor/8e39c6c4ab9a54bd2cd0cf8e81a98442ed067ead28bbc644870c12764f93941d.cairo": "assert [__return_value_ptr] = ret_value.admin_address\nlet __return_value_ptr = __return_value_ptr + 1\n",
+                "autogen/starknet/arg_processor/ac940cac8b8cd37cc8f7b09c26c3e6efc0d3fdc543c4aec1da48233615df03a3.cairo": "let __calldata_arg_new_address = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/arg_processor/c8f8e2249de7b41049de03cb248003121a3f9d075aa868b48f0168d146fac255.cairo": "let __calldata_arg_admin_address = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/arg_processor/e2fbedc064891c9e545cf37f7dc70e5c4c35fcff0b3e3bb5c3f664bdfb47039c.cairo": "assert [__calldata_ptr] = old_admin_address\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
+                "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
+                "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/external/Admin_get_admin_address/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
+                "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
+                "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}()\nlet (range_check_ptr, retdata_size, retdata) = Admin_get_admin_address_encode_return(ret_value, range_check_ptr)\n",
+                "autogen/starknet/external/Admin_get_admin_address/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
+                "autogen/starknet/external/Admin_get_admin_address/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
+                "autogen/starknet/external/Admin_set_admin_address/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
+                "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
+                "autogen/starknet/external/Admin_set_admin_address/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
+                "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(new_address=__calldata_arg_new_address,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
+                "autogen/starknet/external/Admin_set_admin_address/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
+                "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(admin_address=__calldata_arg_admin_address,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
                 "autogen/starknet/external/constructor/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
                 "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(turn_logger_class_hash_=__calldata_arg_turn_logger_class_hash_,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
                 "autogen/starknet/external/constructor/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
                 "autogen/starknet/external/constructor/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/deploy_new_game/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(turn_logger_address=__calldata_arg_turn_logger_address,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
-                "autogen/starknet/external/deploy_new_game/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/deploy_new_game/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/storage_var/salt/decl.cairo": "namespace salt:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
-                "autogen/starknet/storage_var/salt/impl.cairo": "namespace salt:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 166437374298738756398629469846363953049641320050310028217330679862127721328\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend",
-                "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo": "namespace turn_logger_class_hash:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
-                "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo": "namespace turn_logger_class_hash:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 1299003143231291269357344702258825295279884225930719479339419748290133258019\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend"
+                "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo": "func Admin_get_admin_address_encode_return(ret_value : (admin_address : felt), range_check_ptr) -> (\n        range_check_ptr, data_len : felt, data : felt*):\n    %{ memory[ap] = segments.add() %}\n    alloc_locals\n    local __return_value_ptr_start : felt*\n    let __return_value_ptr = __return_value_ptr_start\n    with range_check_ptr:\n    end\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start)\nend\n",
+                "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo": "namespace Admin_admin_address_storage:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        admin_address : felt\n    ):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
+                "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo": "namespace Admin_admin_address_storage:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 378718249152572847617374261773615956577890931335614826062240400943687411152\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        admin_address : felt\n    ):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend"
             },
             "instruction_locations": {
                 "0": {
@@ -347,297 +401,127 @@
                 },
                 "3": {
                     "accessible_scopes": [
-                        "starkware.cairo.lang.compiler.lib.registers",
-                        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc"
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.get_caller_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 72,
-                        "end_line": 6,
+                        "end_col": 90,
+                        "end_line": 196,
                         "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
-                        "start_col": 5,
-                        "start_line": 6
+                        "start_col": 63,
+                        "start_line": 196
                     }
                 },
-                "4": {
+                "5": {
                     "accessible_scopes": [
-                        "starkware.cairo.lang.compiler.lib.registers",
-                        "starkware.cairo.lang.compiler.lib.registers.get_ap"
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.get_caller_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 43,
-                        "end_line": 15,
+                        "end_col": 91,
+                        "end_line": 196,
                         "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
-                        "start_col": 28,
-                        "start_line": 15
+                        "start_col": 5,
+                        "start_line": 196
                     }
                 },
                 "6": {
                     "accessible_scopes": [
-                        "starkware.cairo.lang.compiler.lib.registers",
-                        "starkware.cairo.lang.compiler.lib.registers.get_ap"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 30,
-                        "end_line": 16,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
-                        },
-                        "start_col": 20,
-                        "start_line": 16
-                    }
-                },
-                "8": {
-                    "accessible_scopes": [
-                        "starkware.cairo.lang.compiler.lib.registers",
-                        "starkware.cairo.lang.compiler.lib.registers.get_ap"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 31,
-                        "end_line": 16,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 16
-                    }
-                },
-                "9": {
-                    "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 33,
-                        "end_line": 161,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 18,
-                        "start_line": 161
-                    }
-                },
-                "11": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 160
-                    }
-                },
-                "12": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 160
-                    }
-                },
-                "13": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 160
-                    }
-                },
-                "14": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 160
-                    }
-                },
-                "15": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 160
-                    }
-                },
-                "16": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 19,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 18,
-                        "start_line": 166
-                    }
-                },
-                "18": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 166,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 160
-                    }
-                },
-                "19": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
+                        "starkware.starknet.common.syscalls.get_caller_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [
                         {
                             "location": {
-                                "end_col": 81,
-                                "end_line": 168,
+                                "end_col": 93,
+                                "end_line": 197,
                                 "input_file": {
                                     "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 168
+                                "start_line": 197
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
-                        "end_col": 48,
-                        "end_line": 170,
+                        "end_col": 58,
+                        "end_line": 198,
                         "input_file": {
                             "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 32,
-                                "end_line": 153,
+                                "end_col": 44,
+                                "end_line": 194,
                                 "input_file": {
                                     "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 56,
-                                        "end_line": 172,
+                                        "end_col": 60,
+                                        "end_line": 199,
                                         "input_file": {
                                             "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 172
+                                        "start_line": 199
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
-                                "start_col": 13,
-                                "start_line": 153
+                                "start_col": 25,
+                                "start_line": 194
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 170
+                        "start_line": 198
                     }
                 },
-                "21": {
+                "8": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
+                        "starkware.starknet.common.syscalls.get_caller_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 55,
-                        "end_line": 172,
+                        "end_col": 59,
+                        "end_line": 199,
                         "input_file": {
                             "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
-                        "start_col": 30,
-                        "start_line": 172
+                        "start_col": 28,
+                        "start_line": 199
                     }
                 },
-                "22": {
+                "9": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
+                        "starkware.starknet.common.syscalls.get_caller_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 56,
-                        "end_line": 172,
+                        "end_col": 60,
+                        "end_line": 199,
                         "input_file": {
                             "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 172
+                        "start_line": 199
                     }
                 },
-                "23": {
+                "10": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_read"
@@ -654,7 +538,7 @@
                         "start_line": 348
                     }
                 },
-                "25": {
+                "12": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_read"
@@ -671,7 +555,7 @@
                         "start_line": 348
                     }
                 },
-                "26": {
+                "13": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_read"
@@ -688,7 +572,7 @@
                         "start_line": 348
                     }
                 },
-                "27": {
+                "14": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_read"
@@ -742,7 +626,7 @@
                         "start_line": 351
                     }
                 },
-                "29": {
+                "16": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_read"
@@ -759,7 +643,7 @@
                         "start_line": 352
                     }
                 },
-                "30": {
+                "17": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_read"
@@ -776,7 +660,7 @@
                         "start_line": 352
                     }
                 },
-                "31": {
+                "18": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_write"
@@ -793,7 +677,7 @@
                         "start_line": 366
                     }
                 },
-                "33": {
+                "20": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_write"
@@ -810,7 +694,7 @@
                         "start_line": 365
                     }
                 },
-                "34": {
+                "21": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_write"
@@ -827,7 +711,7 @@
                         "start_line": 365
                     }
                 },
-                "35": {
+                "22": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_write"
@@ -844,7 +728,7 @@
                         "start_line": 365
                     }
                 },
-                "36": {
+                "23": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_write"
@@ -898,7 +782,7 @@
                         "start_line": 368
                     }
                 },
-                "38": {
+                "25": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.storage_write"
@@ -915,7 +799,7 @@
                         "start_line": 369
                     }
                 },
-                "39": {
+                "26": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -932,7 +816,7 @@
                         "start_line": 385
                     }
                 },
-                "41": {
+                "28": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -949,7 +833,7 @@
                         "start_line": 384
                     }
                 },
-                "42": {
+                "29": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -966,7 +850,7 @@
                         "start_line": 384
                     }
                 },
-                "43": {
+                "30": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -983,7 +867,7 @@
                         "start_line": 384
                     }
                 },
-                "44": {
+                "31": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -1000,7 +884,7 @@
                         "start_line": 384
                     }
                 },
-                "45": {
+                "32": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -1017,7 +901,7 @@
                         "start_line": 384
                     }
                 },
-                "46": {
+                "33": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -1071,7 +955,7 @@
                         "start_line": 387
                     }
                 },
-                "48": {
+                "35": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.emit_event"
@@ -1088,11 +972,11 @@
                         "start_line": 388
                     }
                 },
-                "49": {
+                "36": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.addr"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.addr"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1100,21 +984,21 @@
                         "end_col": 42,
                         "end_line": 7,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 42,
                                 "end_line": 7,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 25,
                                         "end_line": 9,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 9,
                                         "start_line": 9
@@ -1130,11 +1014,11 @@
                         "start_line": 7
                     }
                 },
-                "50": {
+                "37": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.addr"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.addr"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1142,21 +1026,21 @@
                         "end_col": 59,
                         "end_line": 7,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 59,
                                 "end_line": 7,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 25,
                                         "end_line": 9,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 9,
                                         "start_line": 9
@@ -1172,11 +1056,11 @@
                         "start_line": 7
                     }
                 },
-                "51": {
+                "38": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.addr"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.addr"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1184,14 +1068,14 @@
                         "end_col": 94,
                         "end_line": 8,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 24,
                                 "end_line": 9,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                 },
                                 "start_col": 21,
                                 "start_line": 9
@@ -1202,11 +1086,11 @@
                         "start_line": 8
                     }
                 },
-                "53": {
+                "40": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.addr"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.addr"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1214,17 +1098,17 @@
                         "end_col": 25,
                         "end_line": 9,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "start_col": 9,
                         "start_line": 9
                     }
                 },
-                "54": {
+                "41": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1232,21 +1116,21 @@
                         "end_col": 63,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 42,
                                 "end_line": 7,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 36,
                                         "end_line": 15,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 30,
                                         "start_line": 15
@@ -1262,11 +1146,11 @@
                         "start_line": 12
                     }
                 },
-                "55": {
+                "42": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1274,21 +1158,21 @@
                         "end_col": 80,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 59,
                                 "end_line": 7,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 36,
                                         "end_line": 15,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 30,
                                         "start_line": 15
@@ -1304,11 +1188,11 @@
                         "start_line": 12
                     }
                 },
-                "56": {
+                "43": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1316,17 +1200,17 @@
                         "end_col": 36,
                         "end_line": 15,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "start_col": 30,
                         "start_line": 15
                     }
                 },
-                "58": {
+                "45": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1334,7 +1218,7 @@
                         "end_col": 34,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
@@ -1348,7 +1232,7 @@
                                         "end_col": 75,
                                         "end_line": 16,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 37,
                                         "start_line": 16
@@ -1364,11 +1248,11 @@
                         "start_line": 12
                     }
                 },
-                "59": {
+                "46": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1376,14 +1260,14 @@
                         "end_col": 26,
                         "end_line": 15,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 70,
                                 "end_line": 16,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                 },
                                 "start_col": 58,
                                 "start_line": 16
@@ -1394,11 +1278,11 @@
                         "start_line": 15
                     }
                 },
-                "60": {
+                "47": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1406,17 +1290,17 @@
                         "end_col": 75,
                         "end_line": 16,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
                         "start_col": 37,
                         "start_line": 16
                     }
                 },
-                "62": {
+                "49": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1431,14 +1315,14 @@
                                 "end_col": 75,
                                 "end_line": 16,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 42,
                                         "end_line": 18,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 31,
                                         "start_line": 18
@@ -1454,11 +1338,11 @@
                         "start_line": 346
                     }
                 },
-                "63": {
+                "50": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1466,21 +1350,21 @@
                         "end_col": 42,
                         "end_line": 7,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 36,
                                 "end_line": 15,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 44,
                                         "end_line": 19,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                         },
                                         "start_col": 32,
                                         "start_line": 19
@@ -1489,6 +1373,360 @@
                                 ],
                                 "start_col": 30,
                                 "start_line": 15
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "51": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 15,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 50,
+                                        "end_line": 20,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                        },
+                                        "start_col": 35,
+                                        "start_line": 20
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 15
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "52": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 33,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 65,
+                                "end_line": 21,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                },
+                                "start_col": 46,
+                                "start_line": 21
+                            },
+                            "While expanding the reference '__storage_var_temp0' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 16
+                    }
+                },
+                "53": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 53,
+                        "end_line": 22,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 22
+                    }
+                },
+                "54": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 26,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 26
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 37,
+                        "start_line": 25
+                    }
+                },
+                "55": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 81,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 26,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 26
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 66,
+                        "start_line": 25
+                    }
+                },
+                "56": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 36,
+                        "end_line": 26,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 26
+                    }
+                },
+                "58": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 35,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 39,
+                                "end_line": 364,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 80,
+                                        "end_line": 27,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 27
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 20,
+                                "start_line": 364
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 16,
+                        "start_line": 25
+                    }
+                },
+                "59": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 26,
+                        "end_line": 26,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 43,
+                                "end_line": 27,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                },
+                                "start_col": 31,
+                                "start_line": 27
+                            },
+                            "While expanding the reference 'storage_addr' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 26
+                    }
+                },
+                "60": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 79,
+                        "end_line": 27,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "start_col": 55,
+                        "start_line": 27
+                    }
+                },
+                "61": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 27,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 27
+                    }
+                },
+                "63": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 26,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 28,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 28
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 37,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 26
                             },
                             "While trying to update the implicit return value 'pedersen_ptr' in:"
                         ],
@@ -1499,8 +1737,8 @@
                 "64": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -1508,29 +1746,41 @@
                         "end_col": 59,
                         "end_line": 7,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 15,
+                                "end_line": 26,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 50,
-                                        "end_line": 20,
+                                        "end_col": 81,
+                                        "end_line": 21,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                         },
-                                        "start_col": 35,
-                                        "start_line": 20
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 28,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 28
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 66,
+                                        "start_line": 21
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 30,
-                                "start_line": 15
+                                "start_line": 26
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
@@ -1541,1226 +1791,26 @@
                 "65": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
+                        "__main__.Admin_admin_address_storage",
+                        "__main__.Admin_admin_address_storage.write"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 33,
-                        "end_line": 16,
+                        "end_col": 18,
+                        "end_line": 28,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/impl.cairo"
                         },
-                        "parent_location": [
-                            {
-                                "end_col": 65,
-                                "end_line": 21,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                },
-                                "start_col": 46,
-                                "start_line": 21
-                            },
-                            "While expanding the reference '__storage_var_temp0' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 16
+                        "start_col": 9,
+                        "start_line": 28
                     }
                 },
                 "66": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.salt",
-                        "__main__.salt.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 53,
-                        "end_line": 22,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 22
-                    }
-                },
-                "67": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 64,
-                        "end_line": 25,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 42,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 36,
-                                        "end_line": 26,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                        },
-                                        "start_col": 30,
-                                        "start_line": 26
-                                    },
-                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 15,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 37,
-                        "start_line": 25
-                    }
-                },
-                "68": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 81,
-                        "end_line": 25,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 59,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 36,
-                                        "end_line": 26,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                        },
-                                        "start_col": 30,
-                                        "start_line": 26
-                                    },
-                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                ],
-                                "start_col": 44,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'range_check_ptr' in:"
-                        ],
-                        "start_col": 66,
-                        "start_line": 25
-                    }
-                },
-                "69": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 36,
-                        "end_line": 26,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "start_col": 30,
-                        "start_line": 26
-                    }
-                },
-                "71": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 35,
-                        "end_line": 25,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 39,
-                                "end_line": 364,
-                                "input_file": {
-                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 80,
-                                        "end_line": 27,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                        },
-                                        "start_col": 9,
-                                        "start_line": 27
-                                    },
-                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                ],
-                                "start_col": 20,
-                                "start_line": 364
-                            },
-                            "While expanding the reference 'syscall_ptr' in:"
-                        ],
-                        "start_col": 16,
-                        "start_line": 25
-                    }
-                },
-                "72": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 26,
-                        "end_line": 26,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 43,
-                                "end_line": 27,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                },
-                                "start_col": 31,
-                                "start_line": 27
-                            },
-                            "While expanding the reference 'storage_addr' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 26
-                    }
-                },
-                "73": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 79,
-                        "end_line": 27,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "start_col": 55,
-                        "start_line": 27
-                    }
-                },
-                "74": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 80,
-                        "end_line": 27,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 27
-                    }
-                },
-                "76": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 42,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 36,
-                                "end_line": 26,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 64,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 18,
-                                                "end_line": 28,
-                                                "input_file": {
-                                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 28
-                                            },
-                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                        ],
-                                        "start_col": 37,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 26
-                            },
-                            "While trying to update the implicit return value 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 15,
-                        "start_line": 7
-                    }
-                },
-                "77": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 59,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 36,
-                                "end_line": 26,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 81,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 18,
-                                                "end_line": 28,
-                                                "input_file": {
-                                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 28
-                                            },
-                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                        ],
-                                        "start_col": 66,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'range_check_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 26
-                            },
-                            "While trying to update the implicit return value 'range_check_ptr' in:"
-                        ],
-                        "start_col": 44,
-                        "start_line": 7
-                    }
-                },
-                "78": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.salt",
-                        "__main__.salt.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 18,
-                        "end_line": 28,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 28
-                    }
-                },
-                "79": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.addr"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 42,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 42,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 25,
-                                        "end_line": 9,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 9,
-                                        "start_line": 9
-                                    },
-                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 15,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 15,
-                        "start_line": 7
-                    }
-                },
-                "80": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.addr"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 59,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 59,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 25,
-                                        "end_line": 9,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 9,
-                                        "start_line": 9
-                                    },
-                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                ],
-                                "start_col": 44,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'range_check_ptr' in:"
-                        ],
-                        "start_col": 44,
-                        "start_line": 7
-                    }
-                },
-                "81": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.addr"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 95,
-                        "end_line": 8,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 24,
-                                "end_line": 9,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "start_col": 21,
-                                "start_line": 9
-                            },
-                            "While expanding the reference 'res' in:"
-                        ],
-                        "start_col": 19,
-                        "start_line": 8
-                    }
-                },
-                "83": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.addr"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 25,
-                        "end_line": 9,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 9
-                    }
-                },
-                "84": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 63,
-                        "end_line": 12,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 42,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 36,
-                                        "end_line": 15,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 30,
-                                        "start_line": 15
-                                    },
-                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 15,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 36,
-                        "start_line": 12
-                    }
-                },
-                "85": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 80,
-                        "end_line": 12,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 59,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 36,
-                                        "end_line": 15,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 30,
-                                        "start_line": 15
-                                    },
-                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                ],
-                                "start_col": 44,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'range_check_ptr' in:"
-                        ],
-                        "start_col": 65,
-                        "start_line": 12
-                    }
-                },
-                "86": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 36,
-                        "end_line": 15,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 30,
-                        "start_line": 15
-                    }
-                },
-                "88": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 34,
-                        "end_line": 12,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 38,
-                                "end_line": 346,
-                                "input_file": {
-                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 75,
-                                        "end_line": 16,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 37,
-                                        "start_line": 16
-                                    },
-                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                ],
-                                "start_col": 19,
-                                "start_line": 346
-                            },
-                            "While expanding the reference 'syscall_ptr' in:"
-                        ],
-                        "start_col": 15,
-                        "start_line": 12
-                    }
-                },
-                "89": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 26,
-                        "end_line": 15,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 70,
-                                "end_line": 16,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "start_col": 58,
-                                "start_line": 16
-                            },
-                            "While expanding the reference 'storage_addr' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 15
-                    }
-                },
-                "90": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 75,
-                        "end_line": 16,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 37,
-                        "start_line": 16
-                    }
-                },
-                "92": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 38,
-                        "end_line": 346,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 75,
-                                "end_line": 16,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 42,
-                                        "end_line": 18,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 31,
-                                        "start_line": 18
-                                    },
-                                    "While expanding the reference 'syscall_ptr' in:"
-                                ],
-                                "start_col": 37,
-                                "start_line": 16
-                            },
-                            "While trying to update the implicit return value 'syscall_ptr' in:"
-                        ],
-                        "start_col": 19,
-                        "start_line": 346
-                    }
-                },
-                "93": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 42,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 36,
-                                "end_line": 15,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 44,
-                                        "end_line": 19,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 32,
-                                        "start_line": 19
-                                    },
-                                    "While expanding the reference 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 15
-                            },
-                            "While trying to update the implicit return value 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 15,
-                        "start_line": 7
-                    }
-                },
-                "94": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 59,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 36,
-                                "end_line": 15,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 50,
-                                        "end_line": 20,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 35,
-                                        "start_line": 20
-                                    },
-                                    "While expanding the reference 'range_check_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 15
-                            },
-                            "While trying to update the implicit return value 'range_check_ptr' in:"
-                        ],
-                        "start_col": 44,
-                        "start_line": 7
-                    }
-                },
-                "95": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 33,
-                        "end_line": 16,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 65,
-                                "end_line": 21,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "start_col": 46,
-                                "start_line": 21
-                            },
-                            "While expanding the reference '__storage_var_temp0' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 16
-                    }
-                },
-                "96": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.read"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 53,
-                        "end_line": 22,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 22
-                    }
-                },
-                "97": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 64,
-                        "end_line": 25,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 42,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 36,
-                                        "end_line": 26,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 30,
-                                        "start_line": 26
-                                    },
-                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 15,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 37,
-                        "start_line": 25
-                    }
-                },
-                "98": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 81,
-                        "end_line": 25,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 59,
-                                "end_line": 7,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 36,
-                                        "end_line": 26,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 30,
-                                        "start_line": 26
-                                    },
-                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                ],
-                                "start_col": 44,
-                                "start_line": 7
-                            },
-                            "While expanding the reference 'range_check_ptr' in:"
-                        ],
-                        "start_col": 66,
-                        "start_line": 25
-                    }
-                },
-                "99": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 36,
-                        "end_line": 26,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 30,
-                        "start_line": 26
-                    }
-                },
-                "101": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 35,
-                        "end_line": 25,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 39,
-                                "end_line": 364,
-                                "input_file": {
-                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 80,
-                                        "end_line": 27,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                        },
-                                        "start_col": 9,
-                                        "start_line": 27
-                                    },
-                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                ],
-                                "start_col": 20,
-                                "start_line": 364
-                            },
-                            "While expanding the reference 'syscall_ptr' in:"
-                        ],
-                        "start_col": 16,
-                        "start_line": 25
-                    }
-                },
-                "102": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 26,
-                        "end_line": 26,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 43,
-                                "end_line": 27,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "start_col": 31,
-                                "start_line": 27
-                            },
-                            "While expanding the reference 'storage_addr' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 26
-                    }
-                },
-                "103": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 79,
-                        "end_line": 27,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 55,
-                        "start_line": 27
-                    }
-                },
-                "104": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 80,
-                        "end_line": 27,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 27
-                    }
-                },
-                "106": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 42,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 36,
-                                "end_line": 26,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 64,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 18,
-                                                "end_line": 28,
-                                                "input_file": {
-                                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 28
-                                            },
-                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                        ],
-                                        "start_col": 37,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 26
-                            },
-                            "While trying to update the implicit return value 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 15,
-                        "start_line": 7
-                    }
-                },
-                "107": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 59,
-                        "end_line": 7,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 36,
-                                "end_line": 26,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 81,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 18,
-                                                "end_line": 28,
-                                                "input_file": {
-                                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 28
-                                            },
-                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                        ],
-                                        "start_col": 66,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'range_check_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 26
-                            },
-                            "While trying to update the implicit return value 'range_check_ptr' in:"
-                        ],
-                        "start_col": 44,
-                        "start_line": 7
-                    }
-                },
-                "108": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_class_hash",
-                        "__main__.turn_logger_class_hash.write"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 18,
-                        "end_line": 28,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/impl.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 28
-                    }
-                },
-                "109": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2768,17 +1818,17 @@
                         "end_col": 13,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2786,11 +1836,11 @@
                         "start_line": 1
                     }
                 },
-                "111": {
+                "68": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2798,17 +1848,17 @@
                         "end_col": 41,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2816,11 +1866,11 @@
                         "start_line": 2
                     }
                 },
-                "113": {
+                "70": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2828,17 +1878,17 @@
                         "end_col": 30,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2846,11 +1896,11 @@
                         "start_line": 2
                     }
                 },
-                "114": {
+                "71": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2858,17 +1908,17 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2876,11 +1926,11 @@
                         "start_line": 3
                     }
                 },
-                "116": {
+                "73": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2888,17 +1938,17 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2906,11 +1956,11 @@
                         "start_line": 3
                     }
                 },
-                "117": {
+                "74": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2918,17 +1968,17 @@
                         "end_col": 41,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2936,11 +1986,11 @@
                         "start_line": 4
                     }
                 },
-                "119": {
+                "76": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -2948,17 +1998,17 @@
                         "end_col": 30,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -2966,41 +2016,71 @@
                         "start_line": 4
                     }
                 },
-                "120": {
+                "77": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 43,
+                        "end_col": 44,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/26f15a9c5452d70e4cc375617f10b6116f9f34527dec544e7a83bf3f2d0d94a6.cairo"
+                            "filename": "autogen/starknet/arg_processor/e2fbedc064891c9e545cf37f7dc70e5c4c35fcff0b3e3bb5c3f664bdfb47039c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 52,
-                                "end_line": 28,
+                                "end_col": 43,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
-                                "start_col": 36,
-                                "start_line": 28
+                                "start_col": 26,
+                                "start_line": 24
                             },
-                            "While handling calldata argument 'contract_address'"
+                            "While handling calldata argument 'old_admin_address'"
                         ],
                         "start_col": 1,
                         "start_line": 1
                     }
                 },
-                "121": {
+                "78": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 38,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/20300ea0c4e496287067a70785a958f9af3a8d44eb9596532186296dbbb6ae49.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 63,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 52,
+                                "start_line": 24
+                            },
+                            "While handling calldata argument 'new_address'"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "79": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3008,31 +2088,31 @@
                         "end_col": 40,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/26f15a9c5452d70e4cc375617f10b6116f9f34527dec544e7a83bf3f2d0d94a6.cairo"
+                            "filename": "autogen/starknet/arg_processor/20300ea0c4e496287067a70785a958f9af3a8d44eb9596532186296dbbb6ae49.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 52,
-                                "end_line": 28,
+                                "end_col": 63,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 64,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 35,
-                                                "end_line": 28,
+                                                "end_col": 25,
+                                                "end_line": 24,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 24
                                             },
                                             "While handling event:"
                                         ],
@@ -3041,20 +2121,20 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 36,
-                                "start_line": 28
+                                "start_col": 52,
+                                "start_line": 24
                             },
-                            "While handling calldata argument 'contract_address'"
+                            "While handling calldata argument 'new_address'"
                         ],
                         "start_col": 22,
                         "start_line": 2
                     }
                 },
-                "123": {
+                "81": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3062,14 +2142,14 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3083,17 +2163,17 @@
                                                 "end_col": 95,
                                                 "end_line": 1,
                                                 "input_file": {
-                                                    "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                    "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 35,
-                                                        "end_line": 28,
+                                                        "end_col": 25,
+                                                        "end_line": 24,
                                                         "input_file": {
-                                                            "filename": "game_factory.cairo"
+                                                            "filename": "admin.cairo"
                                                         },
                                                         "start_col": 6,
-                                                        "start_line": 28
+                                                        "start_line": 24
                                                     },
                                                     "While handling event:"
                                                 ],
@@ -3108,7 +2188,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3116,11 +2196,11 @@
                         "start_line": 1
                     }
                 },
-                "124": {
+                "82": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3128,17 +2208,17 @@
                         "end_col": 22,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3146,11 +2226,11 @@
                         "start_line": 1
                     }
                 },
-                "126": {
+                "84": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3158,31 +2238,31 @@
                         "end_col": 22,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 39,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 35,
-                                                "end_line": 28,
+                                                "end_col": 25,
+                                                "end_line": 24,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 24
                                             },
                                             "While handling event:"
                                         ],
@@ -3192,7 +2272,7 @@
                                     "While expanding the reference '__keys_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3200,11 +2280,11 @@
                         "start_line": 2
                     }
                 },
-                "127": {
+                "85": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3212,17 +2292,17 @@
                         "end_col": 77,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3230,11 +2310,11 @@
                         "start_line": 1
                     }
                 },
-                "128": {
+                "86": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3242,31 +2322,31 @@
                         "end_col": 22,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 94,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 35,
-                                                "end_line": 28,
+                                                "end_col": 25,
+                                                "end_line": 24,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 24
                                             },
                                             "While handling event:"
                                         ],
@@ -3276,7 +2356,7 @@
                                     "While expanding the reference '__data_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3284,11 +2364,11 @@
                         "start_line": 4
                     }
                 },
-                "129": {
+                "87": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3296,17 +2376,17 @@
                         "end_col": 95,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3314,11 +2394,11 @@
                         "start_line": 1
                     }
                 },
-                "131": {
+                "89": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3326,45 +2406,45 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 35,
-                                                "end_line": 28,
+                                                "end_col": 25,
+                                                "end_line": 24,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
                                                         "end_col": 10,
                                                         "end_line": 2,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
-                                                                "end_col": 35,
-                                                                "end_line": 28,
+                                                                "end_col": 25,
+                                                                "end_line": 24,
                                                                 "input_file": {
-                                                                    "filename": "game_factory.cairo"
+                                                                    "filename": "admin.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 28
+                                                                "start_line": 24
                                                             },
                                                             "While handling event:"
                                                         ],
@@ -3374,7 +2454,7 @@
                                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                                 ],
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 24
                                             },
                                             "While handling event:"
                                         ],
@@ -3384,7 +2464,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3392,11 +2472,11 @@
                         "start_line": 1
                     }
                 },
-                "132": {
+                "90": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.turn_logger_contract_deployed",
-                        "__main__.turn_logger_contract_deployed.emit"
+                        "__main__.UpdatedAdminAddress",
+                        "__main__.UpdatedAdminAddress.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -3404,17 +2484,17 @@
                         "end_col": 10,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 28,
+                                "end_col": 25,
+                                "end_line": 24,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 24
                             },
                             "While handling event:"
                         ],
@@ -3422,7 +2502,7 @@
                         "start_line": 2
                     }
                 },
-                "133": {
+                "91": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3431,40 +2511,40 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 24,
-                        "end_line": 37,
+                        "end_col": 28,
+                        "end_line": 33,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 21,
+                                "end_col": 34,
+                                "end_line": 13,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 64,
-                                        "end_line": 41,
+                                        "end_col": 70,
+                                        "end_line": 34,
                                         "input_file": {
-                                            "filename": "game_factory.cairo"
+                                            "filename": "admin.cairo"
                                         },
-                                        "start_col": 5,
-                                        "start_line": 41
+                                        "start_col": 36,
+                                        "start_line": 34
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
-                                "start_col": 16,
-                                "start_line": 21
+                                "start_col": 15,
+                                "start_line": 13
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
-                        "start_col": 5,
-                        "start_line": 37
+                        "start_col": 9,
+                        "start_line": 33
                     }
                 },
-                "134": {
+                "92": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3473,112 +2553,40 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 32,
-                        "end_line": 38,
+                        "end_col": 57,
+                        "end_line": 33,
                         "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 64,
-                                "end_line": 21,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 64,
-                                        "end_line": 41,
-                                        "input_file": {
-                                            "filename": "game_factory.cairo"
-                                        },
-                                        "start_col": 5,
-                                        "start_line": 41
-                                    },
-                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 37,
-                                "start_line": 21
-                            },
-                            "While expanding the reference 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 5,
-                        "start_line": 38
-                    }
-                },
-                "135": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.constructor"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 20,
-                        "end_line": 39,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 81,
-                                "end_line": 21,
-                                "input_file": {
-                                    "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 64,
-                                        "end_line": 41,
-                                        "input_file": {
-                                            "filename": "game_factory.cairo"
-                                        },
-                                        "start_col": 5,
-                                        "start_line": 41
-                                    },
-                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                ],
-                                "start_col": 66,
-                                "start_line": 21
-                            },
-                            "While expanding the reference 'range_check_ptr' in:"
-                        ],
-                        "start_col": 5,
-                        "start_line": 39
-                    }
-                },
-                "136": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.constructor"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 33,
-                        "end_line": 40,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 63,
-                                "end_line": 41,
+                                "end_line": 13,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
-                                "start_col": 40,
-                                "start_line": 41
+                                "parent_location": [
+                                    {
+                                        "end_col": 70,
+                                        "end_line": 34,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 36,
+                                        "start_line": 34
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 36,
+                                "start_line": 13
                             },
-                            "While expanding the reference 'turn_logger_class_hash_' in:"
+                            "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 3,
-                        "start_line": 40
+                        "start_col": 30,
+                        "start_line": 33
                     }
                 },
-                "137": {
+                "93": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3587,16 +2595,286 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
-                        "end_line": 41,
+                        "end_col": 74,
+                        "end_line": 33,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
-                        "start_col": 5,
-                        "start_line": 41
+                        "parent_location": [
+                            {
+                                "end_col": 80,
+                                "end_line": 13,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 70,
+                                        "end_line": 34,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 36,
+                                        "start_line": 34
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 65,
+                                "start_line": 13
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 59,
+                        "start_line": 33
                     }
                 },
-                "139": {
+                "94": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 70,
+                        "end_line": 34,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 36,
+                        "start_line": 34
+                    }
+                },
+                "96": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 36,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 36
+                    }
+                },
+                "98": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 70,
+                                "end_line": 34,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 35,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 53,
+                                                "end_line": 39,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 39
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 16,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 36,
+                                "start_line": 34
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 13
+                    }
+                },
+                "99": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 70,
+                                "end_line": 34,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 53,
+                                                "end_line": 39,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 39
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 37,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 36,
+                                "start_line": 34
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 13
+                    }
+                },
+                "100": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 70,
+                                "end_line": 34,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 81,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 53,
+                                                "end_line": 39,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 39
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 66,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 36,
+                                "start_line": 34
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 13
+                    }
+                },
+                "101": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 96,
+                        "end_line": 33,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 52,
+                                "end_line": 39,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 39,
+                                "start_line": 39
+                            },
+                            "While expanding the reference 'admin_address' in:"
+                        ],
+                        "start_col": 76,
+                        "start_line": 33
+                    }
+                },
+                "102": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 53,
+                        "end_line": 39,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 39
+                    }
+                },
+                "104": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3606,15 +2884,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 14,
-                        "end_line": 42,
+                        "end_line": 40,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 42
+                        "start_line": 40
                     }
                 },
-                "140": {
+                "105": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3627,14 +2905,14 @@
                         "end_col": 40,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/37588e1cf2f26f9b7f01bf8c3fd7176010fcc9855ee3cf16012c7824c2e7a569.cairo"
+                            "filename": "autogen/starknet/arg_processor/c8f8e2249de7b41049de03cb248003121a3f9d075aa868b48f0168d146fac255.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 33,
-                                "end_line": 40,
+                                "end_col": 96,
+                                "end_line": 33,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3646,9 +2924,9 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
@@ -3660,12 +2938,12 @@
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 17,
-                                                                "end_line": 36,
+                                                                "end_line": 32,
                                                                 "input_file": {
-                                                                    "filename": "game_factory.cairo"
+                                                                    "filename": "admin.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 36
+                                                                "start_line": 32
                                                             },
                                                             "While handling calldata of"
                                                         ],
@@ -3675,7 +2953,7 @@
                                                     "While expanding the reference '__calldata_actual_size' in:"
                                                 ],
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While handling calldata of"
                                         ],
@@ -3684,16 +2962,16 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 3,
-                                "start_line": 40
+                                "start_col": 76,
+                                "start_line": 33
                             },
-                            "While handling calldata argument 'turn_logger_class_hash_'"
+                            "While handling calldata argument 'admin_address'"
                         ],
                         "start_col": 22,
                         "start_line": 2
                     }
                 },
-                "142": {
+                "107": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3711,12 +2989,12 @@
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While handling calldata of"
                         ],
@@ -3724,7 +3002,7 @@
                         "start_line": 1
                     }
                 },
-                "143": {
+                "108": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3741,27 +3019,27 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
-                                "end_line": 37,
+                                "end_col": 28,
+                                "end_line": 33,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3770,8 +3048,8 @@
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 37
+                                "start_col": 9,
+                                "start_line": 33
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3779,7 +3057,7 @@
                         "start_line": 1
                     }
                 },
-                "144": {
+                "109": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3796,27 +3074,27 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 32,
-                                "end_line": 38,
+                                "end_col": 57,
+                                "end_line": 33,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3825,8 +3103,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 38
+                                "start_col": 30,
+                                "start_line": 33
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3834,7 +3112,7 @@
                         "start_line": 1
                     }
                 },
-                "145": {
+                "110": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3851,27 +3129,27 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 20,
-                                "end_line": 39,
+                                "end_col": 74,
+                                "end_line": 33,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3880,8 +3158,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 39
+                                "start_col": 59,
+                                "start_line": 33
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3889,7 +3167,7 @@
                         "start_line": 1
                     }
                 },
-                "146": {
+                "111": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3899,52 +3177,52 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 62,
+                        "end_col": 52,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/37588e1cf2f26f9b7f01bf8c3fd7176010fcc9855ee3cf16012c7824c2e7a569.cairo"
+                            "filename": "autogen/starknet/arg_processor/c8f8e2249de7b41049de03cb248003121a3f9d075aa868b48f0168d146fac255.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 33,
-                                "end_line": 40,
+                                "end_col": 96,
+                                "end_line": 33,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 179,
+                                        "end_col": 159,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
-                                        "start_col": 141,
+                                        "start_col": 131,
                                         "start_line": 1
                                     },
-                                    "While expanding the reference '__calldata_arg_turn_logger_class_hash_' in:"
+                                    "While expanding the reference '__calldata_arg_admin_address' in:"
                                 ],
-                                "start_col": 3,
-                                "start_line": 40
+                                "start_col": 76,
+                                "start_line": 33
                             },
-                            "While handling calldata argument 'turn_logger_class_hash_'"
+                            "While handling calldata argument 'admin_address'"
                         ],
-                        "start_col": 46,
+                        "start_col": 36,
                         "start_line": 1
                     }
                 },
-                "147": {
+                "112": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3955,15 +3233,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 17,
-                        "end_line": 36,
+                        "end_line": 32,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 36
+                        "start_line": 32
                     }
                 },
-                "149": {
+                "114": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3977,17 +3255,17 @@
                                 "end_col": 34,
                                 "end_line": 2,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                                    "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 17,
-                                        "end_line": 36,
+                                        "end_line": 32,
                                         "input_file": {
-                                            "filename": "game_factory.cairo"
+                                            "filename": "admin.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 36
+                                        "start_line": 32
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -4001,17 +3279,17 @@
                         "end_col": 24,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4019,7 +3297,7 @@
                         "start_line": 3
                     }
                 },
-                "151": {
+                "116": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4032,14 +3310,14 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4051,12 +3329,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4066,7 +3344,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4074,7 +3352,7 @@
                         "start_line": 1
                     }
                 },
-                "152": {
+                "117": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4087,14 +3365,14 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4106,12 +3384,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4121,7 +3399,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4129,7 +3407,7 @@
                         "start_line": 1
                     }
                 },
-                "153": {
+                "118": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4142,14 +3420,14 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4161,12 +3439,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4176,7 +3454,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4184,7 +3462,7 @@
                         "start_line": 1
                     }
                 },
-                "154": {
+                "119": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4197,14 +3475,14 @@
                         "end_col": 21,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4216,12 +3494,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4231,7 +3509,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4239,7 +3517,7 @@
                         "start_line": 4
                     }
                 },
-                "156": {
+                "121": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4252,14 +3530,14 @@
                         "end_col": 16,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/6ec5627eb372b4fd2782caa60ad00ae308666a957ae7059fee053488a40fe3aa.cairo"
+                            "filename": "autogen/starknet/external/constructor/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4271,12 +3549,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 36,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 36
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4286,7 +3564,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4294,7 +3572,7 @@
                         "start_line": 3
                     }
                 },
-                "157": {
+                "122": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4312,12 +3590,12 @@
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 36,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 36
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4325,36 +3603,36 @@
                         "start_line": 1
                     }
                 },
-                "158": {
+                "123": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__main__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 24,
-                        "end_line": 51,
+                        "end_col": 49,
+                        "end_line": 47,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 34,
                                 "end_line": 13,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 41,
-                                        "end_line": 55,
+                                        "end_col": 61,
+                                        "end_line": 49,
                                         "input_file": {
-                                            "filename": "game_factory.cairo"
+                                            "filename": "admin.cairo"
                                         },
-                                        "start_col": 30,
-                                        "start_line": 55
+                                        "start_col": 27,
+                                        "start_line": 49
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -4363,40 +3641,40 @@
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
-                        "start_col": 5,
-                        "start_line": 51
+                        "start_col": 30,
+                        "start_line": 47
                     }
                 },
-                "159": {
+                "124": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__main__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 32,
-                        "end_line": 52,
+                        "end_col": 78,
+                        "end_line": 47,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 63,
                                 "end_line": 13,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 41,
-                                        "end_line": 55,
+                                        "end_col": 61,
+                                        "end_line": 49,
                                         "input_file": {
-                                            "filename": "game_factory.cairo"
+                                            "filename": "admin.cairo"
                                         },
-                                        "start_col": 30,
-                                        "start_line": 55
+                                        "start_col": 27,
+                                        "start_line": 49
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
@@ -4405,40 +3683,40 @@
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 5,
-                        "start_line": 52
+                        "start_col": 51,
+                        "start_line": 47
                     }
                 },
-                "160": {
+                "125": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__main__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 20,
-                        "end_line": 53,
+                        "end_col": 95,
+                        "end_line": 47,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "admin.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 80,
                                 "end_line": 13,
                                 "input_file": {
-                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 41,
-                                        "end_line": 55,
+                                        "end_col": 61,
+                                        "end_line": 49,
                                         "input_file": {
-                                            "filename": "game_factory.cairo"
+                                            "filename": "admin.cairo"
                                         },
-                                        "start_col": 30,
-                                        "start_line": 55
+                                        "start_col": 27,
+                                        "start_line": 49
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
@@ -4447,1109 +3725,366 @@
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
+                        "start_col": 80,
+                        "start_line": 47
+                    }
+                },
+                "126": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 61,
+                        "end_line": 49,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 27,
+                        "start_line": 49
+                    }
+                },
+                "128": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 27,
+                        "end_line": 50,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
                         "start_col": 5,
-                        "start_line": 53
+                        "start_line": 50
                     }
                 },
-                "161": {
+                "129": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
                     ],
                     "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 41,
-                        "end_line": 55,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 30,
-                        "start_line": 55
-                    }
-                },
-                "163": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 34,
-                        "end_line": 13,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 41,
-                                "end_line": 55,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 38,
+                                "end_line": 3,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 34,
-                                        "end_line": 13,
+                                        "end_col": 29,
+                                        "end_line": 47,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
+                                            "filename": "admin.cairo"
                                         },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 57,
-                                                "end_line": 56,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 28,
-                                                "start_line": 56
-                                            },
-                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                        ],
-                                        "start_col": 15,
-                                        "start_line": 13
+                                        "start_col": 6,
+                                        "start_line": 47
                                     },
-                                    "While expanding the reference 'syscall_ptr' in:"
+                                    "While handling return value of"
                                 ],
-                                "start_col": 30,
-                                "start_line": 55
+                                "start_col": 5,
+                                "start_line": 3
                             },
-                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 17,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While handling return value of"
                         ],
-                        "start_col": 15,
-                        "start_line": 13
+                        "start_col": 5,
+                        "start_line": 4
                     }
                 },
-                "164": {
+                "131": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
-                        "end_line": 13,
+                        "end_col": 54,
+                        "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                            "filename": "autogen/starknet/arg_processor/8e39c6c4ab9a54bd2cd0cf8e81a98442ed067ead28bbc644870c12764f93941d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 41,
-                                "end_line": 55,
+                                "end_col": 35,
+                                "end_line": 48,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 15,
+                                "start_line": 48
+                            },
+                            "While handling return value 'admin_address'"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "132": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 48,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/8e39c6c4ab9a54bd2cd0cf8e81a98442ed067ead28bbc644870c12764f93941d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 35,
+                                "end_line": 48,
+                                "input_file": {
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 63,
-                                        "end_line": 13,
+                                        "end_col": 36,
+                                        "end_line": 11,
                                         "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
+                                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 57,
-                                                "end_line": 56,
+                                                "end_col": 29,
+                                                "end_line": 47,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
-                                                "start_col": 28,
-                                                "start_line": 56
+                                                "start_col": 6,
+                                                "start_line": 47
                                             },
-                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                            "While handling return value of"
                                         ],
-                                        "start_col": 36,
-                                        "start_line": 13
+                                        "start_col": 18,
+                                        "start_line": 11
                                     },
-                                    "While expanding the reference 'pedersen_ptr' in:"
+                                    "While expanding the reference '__return_value_ptr' in:"
                                 ],
-                                "start_col": 30,
-                                "start_line": 55
+                                "start_col": 15,
+                                "start_line": 48
                             },
-                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                            "While handling return value 'admin_address'"
                         ],
-                        "start_col": 36,
-                        "start_line": 13
-                    }
-                },
-                "165": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 80,
-                        "end_line": 13,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 41,
-                                "end_line": 55,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 80,
-                                        "end_line": 13,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 57,
-                                                "end_line": 56,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 28,
-                                                "start_line": 56
-                                            },
-                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                        ],
-                                        "start_col": 65,
-                                        "start_line": 13
-                                    },
-                                    "While expanding the reference 'range_check_ptr' in:"
-                                ],
-                                "start_col": 30,
-                                "start_line": 55
-                            },
-                            "While trying to update the implicit return value 'range_check_ptr' in:"
-                        ],
-                        "start_col": 65,
-                        "start_line": 13
-                    }
-                },
-                "166": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 57,
-                        "end_line": 56,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 28,
-                        "start_line": 56
-                    }
-                },
-                "168": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 33,
-                        "end_line": 54,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 63,
-                                "end_line": 61,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "start_col": 44,
-                                "start_line": 61
-                            },
-                            "While expanding the reference 'turn_logger_address' in:"
-                        ],
-                        "start_col": 7,
-                        "start_line": 54
-                    }
-                },
-                "169": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 73,
-                        "end_line": 61,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 34,
-                        "start_line": 61
-                    }
-                },
-                "171": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 73,
-                        "end_line": 61,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 34,
-                        "start_line": 61
-                    }
-                },
-                "173": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 34,
-                        "end_line": 13,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 57,
-                                "end_line": 56,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 32,
-                                        "end_line": 153,
-                                        "input_file": {
-                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 10,
-                                                "end_line": 62,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 34,
-                                                "start_line": 57
-                                            },
-                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                        ],
-                                        "start_col": 13,
-                                        "start_line": 153
-                                    },
-                                    "While expanding the reference 'syscall_ptr' in:"
-                                ],
-                                "start_col": 28,
-                                "start_line": 56
-                            },
-                            "While trying to update the implicit return value 'syscall_ptr' in:"
-                        ],
-                        "start_col": 15,
-                        "start_line": 13
-                    }
-                },
-                "174": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 24,
-                        "end_line": 56,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 34,
-                                "end_line": 58,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "start_col": 24,
-                                "start_line": 58
-                            },
-                            "While expanding the reference 'class_hash' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 56
-                    }
-                },
-                "175": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 26,
-                        "end_line": 55,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 47,
-                                "end_line": 59,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "start_col": 35,
-                                "start_line": 59
-                            },
-                            "While expanding the reference 'current_salt' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 55
-                    }
-                },
-                "176": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 40,
-                        "end_line": 60,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 39,
-                        "start_line": 60
-                    }
-                },
-                "178": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 73,
-                        "end_line": 61,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 34,
-                        "start_line": 61
-                    }
-                },
-                "179": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 10,
-                        "end_line": 62,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 34,
-                        "start_line": 57
-                    }
-                },
-                "181": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 32,
-                        "end_line": 153,
-                        "input_file": {
-                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 10,
-                                "end_line": 62,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 35,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 43,
-                                                "end_line": 63,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 63
-                                            },
-                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                        ],
-                                        "start_col": 16,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'syscall_ptr' in:"
-                                ],
-                                "start_col": 34,
-                                "start_line": 57
-                            },
-                            "While trying to update the implicit return value 'syscall_ptr' in:"
-                        ],
-                        "start_col": 13,
-                        "start_line": 153
-                    }
-                },
-                "182": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 63,
-                        "end_line": 13,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 57,
-                                "end_line": 56,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 64,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 43,
-                                                "end_line": 63,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 63
-                                            },
-                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                        ],
-                                        "start_col": 37,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 28,
-                                "start_line": 56
-                            },
-                            "While trying to update the implicit return value 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 36,
-                        "start_line": 13
-                    }
-                },
-                "183": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 80,
-                        "end_line": 13,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/turn_logger_class_hash/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 57,
-                                "end_line": 56,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 81,
-                                        "end_line": 21,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 43,
-                                                "end_line": 63,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 63
-                                            },
-                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                        ],
-                                        "start_col": 66,
-                                        "start_line": 21
-                                    },
-                                    "While expanding the reference 'range_check_ptr' in:"
-                                ],
-                                "start_col": 28,
-                                "start_line": 56
-                            },
-                            "While trying to update the implicit return value 'range_check_ptr' in:"
-                        ],
-                        "start_col": 65,
-                        "start_line": 13
-                    }
-                },
-                "184": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 42,
-                        "end_line": 63,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
                         "start_col": 26,
-                        "start_line": 63
+                        "start_line": 2
                     }
                 },
-                "186": {
+                "134": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 43,
-                        "end_line": 63,
+                        "end_col": 95,
+                        "end_line": 1,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
                         },
-                        "start_col": 9,
-                        "start_line": 63
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 40,
+                                        "end_line": 10,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While handling return value of"
+                                        ],
+                                        "start_col": 25,
+                                        "start_line": 10
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While handling return value of"
+                        ],
+                        "start_col": 80,
+                        "start_line": 1
                     }
                 },
-                "188": {
+                "135": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 11,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While handling return value of"
+                        ],
+                        "start_col": 18,
+                        "start_line": 11
+                    }
+                },
+                "136": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
                         "end_col": 35,
-                        "end_line": 21,
+                        "end_line": 5,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 43,
-                                "end_line": 63,
+                                "end_col": 29,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 30,
-                                        "end_line": 1,
+                                        "end_col": 38,
+                                        "end_line": 12,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 35,
-                                                "end_line": 28,
+                                                "end_col": 29,
+                                                "end_line": 47,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
-                                                "parent_location": [
-                                                    {
-                                                        "end_col": 10,
-                                                        "end_line": 67,
-                                                        "input_file": {
-                                                            "filename": "game_factory.cairo"
-                                                        },
-                                                        "start_col": 9,
-                                                        "start_line": 65
-                                                    },
-                                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                                ],
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 47
                                             },
-                                            "While handling event:"
+                                            "While handling return value of"
                                         ],
-                                        "start_col": 11,
-                                        "start_line": 1
+                                        "start_col": 14,
+                                        "start_line": 12
                                     },
-                                    "While expanding the reference 'syscall_ptr' in:"
-                                ],
-                                "start_col": 9,
-                                "start_line": 63
-                            },
-                            "While trying to update the implicit return value 'syscall_ptr' in:"
-                        ],
-                        "start_col": 16,
-                        "start_line": 21
-                    }
-                },
-                "189": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 81,
-                        "end_line": 21,
-                        "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 43,
-                                "end_line": 63,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 47,
-                                        "end_line": 1,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 35,
-                                                "end_line": 28,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "parent_location": [
-                                                    {
-                                                        "end_col": 10,
-                                                        "end_line": 67,
-                                                        "input_file": {
-                                                            "filename": "game_factory.cairo"
-                                                        },
-                                                        "start_col": 9,
-                                                        "start_line": 65
-                                                    },
-                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                                ],
-                                                "start_col": 6,
-                                                "start_line": 28
-                                            },
-                                            "While handling event:"
-                                        ],
-                                        "start_col": 32,
-                                        "start_line": 1
-                                    },
-                                    "While expanding the reference 'range_check_ptr' in:"
-                                ],
-                                "start_col": 9,
-                                "start_line": 63
-                            },
-                            "While trying to update the implicit return value 'range_check_ptr' in:"
-                        ],
-                        "start_col": 66,
-                        "start_line": 21
-                    }
-                },
-                "190": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 30,
-                        "end_line": 57,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 46,
-                                "end_line": 66,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "start_col": 30,
-                                "start_line": 66
-                            },
-                            "While expanding the reference 'contract_address' in:"
-                        ],
-                        "start_col": 14,
-                        "start_line": 57
-                    }
-                },
-                "191": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 10,
-                        "end_line": 67,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 65
-                    }
-                },
-                "193": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 30,
-                        "end_line": 1,
-                        "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 35,
-                                "end_line": 28,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 10,
-                                        "end_line": 67,
-                                        "input_file": {
-                                            "filename": "game_factory.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 24,
-                                                "end_line": 51,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "parent_location": [
-                                                    {
-                                                        "end_col": 18,
-                                                        "end_line": 68,
-                                                        "input_file": {
-                                                            "filename": "game_factory.cairo"
-                                                        },
-                                                        "start_col": 9,
-                                                        "start_line": 68
-                                                    },
-                                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                                ],
-                                                "start_col": 5,
-                                                "start_line": 51
-                                            },
-                                            "While expanding the reference 'syscall_ptr' in:"
-                                        ],
-                                        "start_col": 9,
-                                        "start_line": 65
-                                    },
-                                    "While trying to update the implicit return value 'syscall_ptr' in:"
+                                    "While expanding the reference '__return_value_ptr_start' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 47
                             },
-                            "While handling event:"
+                            "While handling return value of"
                         ],
                         "start_col": 11,
-                        "start_line": 1
+                        "start_line": 5
                     }
                 },
-                "194": {
+                "137": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
-                        "__main__.deploy_new_game"
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address_encode_return"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
-                        "end_line": 21,
+                        "end_col": 39,
+                        "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                            "filename": "autogen/starknet/external/return/Admin_get_admin_address/04c1f1991db3e630352bad8130ffd815f0619ec41aa363aeaffa343b796d4bb4.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 43,
-                                "end_line": 63,
+                                "end_col": 29,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
-                                "parent_location": [
-                                    {
-                                        "end_col": 32,
-                                        "end_line": 52,
-                                        "input_file": {
-                                            "filename": "game_factory.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 18,
-                                                "end_line": 68,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 9,
-                                                "start_line": 68
-                                            },
-                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
-                                        ],
-                                        "start_col": 5,
-                                        "start_line": 52
-                                    },
-                                    "While expanding the reference 'pedersen_ptr' in:"
-                                ],
-                                "start_col": 9,
-                                "start_line": 63
-                            },
-                            "While trying to update the implicit return value 'pedersen_ptr' in:"
-                        ],
-                        "start_col": 37,
-                        "start_line": 21
-                    }
-                },
-                "195": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 47,
-                        "end_line": 1,
-                        "input_file": {
-                            "filename": "autogen/starknet/event/turn_logger_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 35,
-                                "end_line": 28,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 10,
-                                        "end_line": 67,
-                                        "input_file": {
-                                            "filename": "game_factory.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 20,
-                                                "end_line": 53,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "parent_location": [
-                                                    {
-                                                        "end_col": 18,
-                                                        "end_line": 68,
-                                                        "input_file": {
-                                                            "filename": "game_factory.cairo"
-                                                        },
-                                                        "start_col": 9,
-                                                        "start_line": 68
-                                                    },
-                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
-                                                ],
-                                                "start_col": 5,
-                                                "start_line": 53
-                                            },
-                                            "While expanding the reference 'range_check_ptr' in:"
-                                        ],
-                                        "start_col": 9,
-                                        "start_line": 65
-                                    },
-                                    "While trying to update the implicit return value 'range_check_ptr' in:"
-                                ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 47
                             },
-                            "While handling event:"
+                            "While handling return value of"
                         ],
-                        "start_col": 32,
-                        "start_line": 1
+                        "start_col": 5,
+                        "start_line": 9
                     }
                 },
-                "196": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__main__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 18,
-                        "end_line": 68,
-                        "input_file": {
-                            "filename": "game_factory.cairo"
-                        },
-                        "start_col": 9,
-                        "start_line": 68
-                    }
-                },
-                "197": {
+                "138": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 40,
-                        "end_line": 2,
-                        "input_file": {
-                            "filename": "autogen/starknet/arg_processor/88f1edfceab034fcb920964e151fec1deaca60c9f795967e361683ce28253d8b.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 33,
-                                "end_line": 54,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 45,
-                                        "end_line": 1,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 21,
-                                                "end_line": 50,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "parent_location": [
-                                                    {
-                                                        "end_col": 57,
-                                                        "end_line": 1,
-                                                        "input_file": {
-                                                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
-                                                        },
-                                                        "parent_location": [
-                                                            {
-                                                                "end_col": 21,
-                                                                "end_line": 50,
-                                                                "input_file": {
-                                                                    "filename": "game_factory.cairo"
-                                                                },
-                                                                "start_col": 6,
-                                                                "start_line": 50
-                                                            },
-                                                            "While handling calldata of"
-                                                        ],
-                                                        "start_col": 35,
-                                                        "start_line": 1
-                                                    },
-                                                    "While expanding the reference '__calldata_actual_size' in:"
-                                                ],
-                                                "start_col": 6,
-                                                "start_line": 50
-                                            },
-                                            "While handling calldata of"
-                                        ],
-                                        "start_col": 31,
-                                        "start_line": 1
-                                    },
-                                    "While expanding the reference '__calldata_ptr' in:"
-                                ],
-                                "start_col": 7,
-                                "start_line": 54
-                            },
-                            "While handling calldata argument 'turn_logger_address'"
-                        ],
-                        "start_col": 22,
-                        "start_line": 2
-                    }
-                },
-                "199": {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5561,13 +4096,13 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 47
                             },
                             "While handling calldata of"
                         ],
@@ -5575,12 +4110,12 @@
                         "start_line": 1
                     }
                 },
-                "200": {
+                "139": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5588,31 +4123,31 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
-                                "end_line": 51,
+                                "end_col": 49,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 47,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 47
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5621,8 +4156,8 @@
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 51
+                                "start_col": 30,
+                                "start_line": 47
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5630,12 +4165,12 @@
                         "start_line": 1
                     }
                 },
-                "201": {
+                "140": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5643,31 +4178,31 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 32,
-                                "end_line": 52,
+                                "end_col": 78,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 47,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 47
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5676,8 +4211,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 52
+                                "start_col": 51,
+                                "start_line": 47
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5685,12 +4220,12 @@
                         "start_line": 1
                     }
                 },
-                "202": {
+                "141": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5698,31 +4233,31 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 20,
-                                "end_line": 53,
+                                "end_col": 95,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 47,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 47
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5731,8 +4266,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 53
+                                "start_col": 80,
+                                "start_line": 47
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5740,86 +4275,1558 @@
                         "start_line": 1
                     }
                 },
-                "203": {
+                "142": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 58,
-                        "end_line": 1,
+                        "end_col": 29,
+                        "end_line": 47,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/88f1edfceab034fcb920964e151fec1deaca60c9f795967e361683ce28253d8b.cairo"
+                            "filename": "admin.cairo"
                         },
-                        "parent_location": [
-                            {
-                                "end_col": 33,
-                                "end_line": 54,
-                                "input_file": {
-                                    "filename": "game_factory.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 171,
-                                        "end_line": 1,
-                                        "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
-                                        },
-                                        "parent_location": [
-                                            {
-                                                "end_col": 21,
-                                                "end_line": 50,
-                                                "input_file": {
-                                                    "filename": "game_factory.cairo"
-                                                },
-                                                "start_col": 6,
-                                                "start_line": 50
-                                            },
-                                            "While constructing the external wrapper for:"
-                                        ],
-                                        "start_col": 137,
-                                        "start_line": 1
-                                    },
-                                    "While expanding the reference '__calldata_arg_turn_logger_address' in:"
-                                ],
-                                "start_col": 7,
-                                "start_line": 54
-                            },
-                            "While handling calldata argument 'turn_logger_address'"
-                        ],
-                        "start_col": 42,
-                        "start_line": 1
+                        "start_col": 6,
+                        "start_line": 47
                     }
                 },
-                "204": {
+                "144": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 115,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 112,
+                                        "end_line": 2,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 97,
+                                        "start_line": 2
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 100,
+                        "start_line": 1
+                    }
+                },
+                "145": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 113,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 48,
+                        "start_line": 2
+                    }
+                },
+                "147": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 55,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 20,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 9,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 1
+                    }
+                },
+                "148": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 82,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 33,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 21,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 70,
+                        "start_line": 1
+                    }
+                },
+                "149": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
                         "end_col": 21,
-                        "end_line": 50,
+                        "end_line": 2,
                         "input_file": {
-                            "filename": "game_factory.cairo"
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
                         },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 49,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 34,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
                         "start_col": 6,
-                        "start_line": 50
+                        "start_line": 2
                     }
                 },
-                "206": {
+                "150": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 35,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 62,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 50,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'retdata_size' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 2
+                    }
+                },
+                "151": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 44,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/79afbcbf3393bda681741e39b99e3a9be47450f4025ee2af15a00d76486c406d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 70,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 47
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 63,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'retdata' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 37,
+                        "start_line": 2
+                    }
+                },
+                "152": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_get_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_get_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "153": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 49,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 70,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 23,
+                                        "end_line": 59,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 59
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 23,
+                                "start_line": 70
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 30,
+                        "start_line": 57
+                    }
+                },
+                "154": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 78,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 71,
+                                "end_line": 70,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 23,
+                                        "end_line": 59,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 59
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 70
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 51,
+                        "start_line": 57
+                    }
+                },
+                "155": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 95,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 88,
+                                "end_line": 70,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 23,
+                                        "end_line": 59,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 59
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 73,
+                                "start_line": 70
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 80,
+                        "start_line": 57
+                    }
+                },
+                "156": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 23,
+                        "end_line": 59,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 59
+                    }
+                },
+                "158": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 65,
+                        "end_line": 60,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 31,
+                        "start_line": 60
+                    }
+                },
+                "160": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 65,
+                                "end_line": 60,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 35,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 51,
+                                                "end_line": 61,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 61
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 16,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 31,
+                                "start_line": 60
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 13
+                    }
+                },
+                "161": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 65,
+                                "end_line": 60,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 51,
+                                                "end_line": 61,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 61
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 37,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 31,
+                                "start_line": 60
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 13
+                    }
+                },
+                "162": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 65,
+                                "end_line": 60,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 81,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 51,
+                                                "end_line": 61,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 61
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 66,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 31,
+                                "start_line": 60
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 13
+                    }
+                },
+                "163": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 27,
+                        "end_line": 58,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 50,
+                                "end_line": 61,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 39,
+                                "start_line": 61
+                            },
+                            "While expanding the reference 'new_address' in:"
+                        ],
+                        "start_col": 9,
+                        "start_line": 58
+                    }
+                },
+                "164": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 51,
+                        "end_line": 61,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 61
+                    }
+                },
+                "166": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 35,
+                        "end_line": 21,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 61,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 30,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 25,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 61,
+                                                        "end_line": 62,
+                                                        "input_file": {
+                                                            "filename": "admin.cairo"
+                                                        },
+                                                        "start_col": 5,
+                                                        "start_line": 62
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 11,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 61
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 16,
+                        "start_line": 21
+                    }
+                },
+                "167": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 81,
+                        "end_line": 21,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 61,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 47,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 25,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 61,
+                                                        "end_line": 62,
+                                                        "input_file": {
+                                                            "filename": "admin.cairo"
+                                                        },
+                                                        "start_col": 5,
+                                                        "start_line": 62
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 32,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 61
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 66,
+                        "start_line": 21
+                    }
+                },
+                "168": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 27,
+                        "end_line": 60,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 47,
+                                "end_line": 62,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 30,
+                                "start_line": 62
+                            },
+                            "While expanding the reference 'old_admin_address' in:"
+                        ],
+                        "start_col": 10,
+                        "start_line": 60
+                    }
+                },
+                "169": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 27,
+                        "end_line": 58,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 60,
+                                "end_line": 62,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 49,
+                                "start_line": 62
+                            },
+                            "While expanding the reference 'new_address' in:"
+                        ],
+                        "start_col": 9,
+                        "start_line": 58
+                    }
+                },
+                "170": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 61,
+                        "end_line": 62,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 62
+                    }
+                },
+                "172": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 25,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 61,
+                                        "end_line": 62,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 49,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 14,
+                                                        "end_line": 63,
+                                                        "input_file": {
+                                                            "filename": "admin.cairo"
+                                                        },
+                                                        "start_col": 5,
+                                                        "start_line": 63
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                                ],
+                                                "start_col": 30,
+                                                "start_line": 57
+                                            },
+                                            "While expanding the reference 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 5,
+                                        "start_line": 62
+                                    },
+                                    "While trying to update the implicit return value 'syscall_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 11,
+                        "start_line": 1
+                    }
+                },
+                "173": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 21,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 61,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 78,
+                                        "end_line": 57,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 14,
+                                                "end_line": 63,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 63
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 51,
+                                        "start_line": 57
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 61
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 37,
+                        "start_line": 21
+                    }
+                },
+                "174": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 47,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/UpdatedAdminAddress/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 25,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 61,
+                                        "end_line": 62,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 95,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 14,
+                                                        "end_line": 63,
+                                                        "input_file": {
+                                                            "filename": "admin.cairo"
+                                                        },
+                                                        "start_col": 5,
+                                                        "start_line": 63
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                                ],
+                                                "start_col": 80,
+                                                "start_line": 57
+                                            },
+                                            "While expanding the reference 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 5,
+                                        "start_line": 62
+                                    },
+                                    "While trying to update the implicit return value 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 32,
+                        "start_line": 1
+                    }
+                },
+                "175": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 14,
+                        "end_line": 63,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 63
+                    }
+                },
+                "176": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 40,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/ac940cac8b8cd37cc8f7b09c26c3e6efc0d3fdc543c4aec1da48233615df03a3.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 27,
+                                "end_line": 58,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 45,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 57,
+                                                        "end_line": 1,
+                                                        "input_file": {
+                                                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                                                        },
+                                                        "parent_location": [
+                                                            {
+                                                                "end_col": 29,
+                                                                "end_line": 57,
+                                                                "input_file": {
+                                                                    "filename": "admin.cairo"
+                                                                },
+                                                                "start_col": 6,
+                                                                "start_line": 57
+                                                            },
+                                                            "While handling calldata of"
+                                                        ],
+                                                        "start_col": 35,
+                                                        "start_line": 1
+                                                    },
+                                                    "While expanding the reference '__calldata_actual_size' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 57
+                                            },
+                                            "While handling calldata of"
+                                        ],
+                                        "start_col": 31,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_ptr' in:"
+                                ],
+                                "start_col": 9,
+                                "start_line": 58
+                            },
+                            "While handling calldata argument 'new_address'"
+                        ],
+                        "start_col": 22,
+                        "start_line": 2
+                    }
+                },
+                "178": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 57,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 29,
+                                "end_line": 57,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 57
+                            },
+                            "While handling calldata of"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "179": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 49,
+                                "end_line": 57,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 55,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 57
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 44,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 57
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 1
+                    }
+                },
+                "180": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 110,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 78,
+                                "end_line": 57,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 82,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 57
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 70,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 51,
+                                "start_line": 57
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 20,
+                        "start_line": 1
+                    }
+                },
+                "181": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 67,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 95,
+                                "end_line": 57,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 115,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 57
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 100,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 80,
+                                "start_line": 57
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 1
+                    }
+                },
+                "182": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 50,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/ac940cac8b8cd37cc8f7b09c26c3e6efc0d3fdc543c4aec1da48233615df03a3.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 27,
+                                "end_line": 58,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 155,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 29,
+                                                "end_line": 57,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 57
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 129,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_arg_new_address' in:"
+                                ],
+                                "start_col": 9,
+                                "start_line": 58
+                            },
+                            "While handling calldata argument 'new_address'"
+                        ],
+                        "start_col": 34,
+                        "start_line": 1
+                    }
+                },
+                "183": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 29,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 57
+                    }
+                },
+                "185": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [
@@ -5828,17 +5835,17 @@
                                 "end_col": 34,
                                 "end_line": 2,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                                    "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 21,
-                                        "end_line": 50,
+                                        "end_col": 29,
+                                        "end_line": 57,
                                         "input_file": {
-                                            "filename": "game_factory.cairo"
+                                            "filename": "admin.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 50
+                                        "start_line": 57
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -5852,17 +5859,17 @@
                         "end_col": 24,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5870,12 +5877,12 @@
                         "start_line": 3
                     }
                 },
-                "208": {
+                "187": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5883,31 +5890,31 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 57,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 57
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5917,7 +5924,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5925,12 +5932,12 @@
                         "start_line": 1
                     }
                 },
-                "209": {
+                "188": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5938,31 +5945,31 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 57,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 57
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5972,7 +5979,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5980,12 +5987,12 @@
                         "start_line": 1
                     }
                 },
-                "210": {
+                "189": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -5993,31 +6000,31 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 57,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 57
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6027,7 +6034,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6035,12 +6042,12 @@
                         "start_line": 1
                     }
                 },
-                "211": {
+                "190": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -6048,31 +6055,31 @@
                         "end_col": 21,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 57,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 57
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6082,7 +6089,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6090,12 +6097,12 @@
                         "start_line": 4
                     }
                 },
-                "213": {
+                "192": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -6103,31 +6110,31 @@
                         "end_col": 16,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/6a1477945e1be601b4677942867d33492308f0a5050e5b2eb039176906277b06.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/d0e08729a7c28c6b027aafa88df071caeb79a8dd438badaf8cdf939d96f67444.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 21,
-                                                "end_line": 50,
+                                                "end_col": 29,
+                                                "end_line": 57,
                                                 "input_file": {
-                                                    "filename": "game_factory.cairo"
+                                                    "filename": "admin.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 50
+                                                "start_line": 57
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6137,7 +6144,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6145,12 +6152,12 @@
                         "start_line": 3
                     }
                 },
-                "214": {
+                "193": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -6158,22 +6165,425 @@
                         "end_col": 71,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/Admin_set_admin_address/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 21,
-                                "end_line": 50,
+                                "end_col": 29,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "game_factory.cairo"
+                                    "filename": "admin.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 50
+                                "start_line": 57
                             },
                             "While constructing the external wrapper for:"
                         ],
                         "start_col": 1,
                         "start_line": 1
+                    }
+                },
+                "194": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 70,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 44,
+                                "end_line": 194,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 48,
+                                        "end_line": 71,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 28,
+                                        "start_line": 71
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 25,
+                                "start_line": 194
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 70
+                    }
+                },
+                "195": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 48,
+                        "end_line": 71,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 28,
+                        "start_line": 71
+                    }
+                },
+                "197": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 44,
+                        "end_line": 194,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 48,
+                                "end_line": 71,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 34,
+                                        "end_line": 13,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 61,
+                                                "end_line": 72,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 27,
+                                                "start_line": 72
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 15,
+                                        "start_line": 13
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 28,
+                                "start_line": 71
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 25,
+                        "start_line": 194
+                    }
+                },
+                "198": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 70,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 63,
+                                "end_line": 13,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 61,
+                                        "end_line": 72,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 27,
+                                        "start_line": 72
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 36,
+                                "start_line": 13
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 70
+                    }
+                },
+                "199": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 88,
+                        "end_line": 70,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 80,
+                                "end_line": 13,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 61,
+                                        "end_line": 72,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "start_col": 27,
+                                        "start_line": 72
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 65,
+                                "start_line": 13
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 73,
+                        "start_line": 70
+                    }
+                },
+                "200": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 61,
+                        "end_line": 72,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 27,
+                        "start_line": 72
+                    }
+                },
+                "202": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 46,
+                        "end_line": 74,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 74
+                    }
+                },
+                "203": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 61,
+                                "end_line": 72,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 42,
+                                        "end_line": 70,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 14,
+                                                "end_line": 76,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 76
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 23,
+                                        "start_line": 70
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 27,
+                                "start_line": 72
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 13
+                    }
+                },
+                "204": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 61,
+                                "end_line": 72,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 71,
+                                        "end_line": 70,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 14,
+                                                "end_line": 76,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 76
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 44,
+                                        "start_line": 70
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 27,
+                                "start_line": 72
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 13
+                    }
+                },
+                "205": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/Admin_admin_address_storage/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 61,
+                                "end_line": 72,
+                                "input_file": {
+                                    "filename": "admin.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 88,
+                                        "end_line": 70,
+                                        "input_file": {
+                                            "filename": "admin.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 14,
+                                                "end_line": 76,
+                                                "input_file": {
+                                                    "filename": "admin.cairo"
+                                                },
+                                                "start_col": 5,
+                                                "start_line": 76
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 73,
+                                        "start_line": 70
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 27,
+                                "start_line": 72
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 13
+                    }
+                },
+                "206": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.Admin_only_admin"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 14,
+                        "end_line": 76,
+                        "input_file": {
+                            "filename": "admin.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 76
                     }
                 }
             }
@@ -6195,25 +6605,25 @@
                     }
                 }
             ],
-            "19": [
+            "6": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.deploy"
+                        "starkware.starknet.common.syscalls.get_caller_address"
                     ],
-                    "code": "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "code": "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 3,
-                            "offset": 2
+                            "group": 1,
+                            "offset": 1
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.syscalls.deploy.syscall_ptr": 0
+                            "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr": 0
                         }
                     }
                 }
             ],
-            "27": [
+            "14": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
@@ -6222,7 +6632,7 @@
                     "code": "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 4,
+                            "group": 2,
                             "offset": 1
                         },
                         "reference_ids": {
@@ -6231,7 +6641,7 @@
                     }
                 }
             ],
-            "36": [
+            "23": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
@@ -6240,7 +6650,7 @@
                     "code": "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 5,
+                            "group": 3,
                             "offset": 1
                         },
                         "reference_ids": {
@@ -6249,7 +6659,7 @@
                     }
                 }
             ],
-            "46": [
+            "33": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
@@ -6258,7 +6668,7 @@
                     "code": "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 6,
+                            "group": 4,
                             "offset": 1
                         },
                         "reference_ids": {
@@ -6267,7 +6677,7 @@
                     }
                 }
             ],
-            "149": [
+            "114": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -6278,26 +6688,44 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 15,
-                            "offset": 29
+                            "group": 10,
+                            "offset": 52
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "206": [
+            "129": [
                 {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
-                        "__wrappers__.deploy_new_game"
+                        "__wrappers__.Admin_get_admin_address_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "185": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.Admin_set_admin_address"
                     ],
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
                             "group": 17,
-                            "offset": 121
+                            "offset": 0
                         },
                         "reference_ids": {}
                     }
@@ -6305,25 +6733,384 @@
             ]
         },
         "identifiers": {
+            "__main__.Admin_admin_address_storage": {
+                "type": "namespace"
+            },
+            "__main__.Admin_admin_address_storage.Args": {
+                "full_name": "__main__.Admin_admin_address_storage.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.Admin_admin_address_storage.ImplicitArgs": {
+                "full_name": "__main__.Admin_admin_address_storage.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.Admin_admin_address_storage.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.Admin_admin_address_storage.addr": {
+                "decorators": [],
+                "pc": 36,
+                "type": "function"
+            },
+            "__main__.Admin_admin_address_storage.addr.Args": {
+                "full_name": "__main__.Admin_admin_address_storage.addr.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.addr.ImplicitArgs": {
+                "full_name": "__main__.Admin_admin_address_storage.addr.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 0
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.addr.Return": {
+                "cairo_type": "(res : felt)",
+                "type": "type_definition"
+            },
+            "__main__.Admin_admin_address_storage.addr.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.Admin_admin_address_storage.hash2": {
+                "destination": "starkware.cairo.common.hash.hash2",
+                "type": "alias"
+            },
+            "__main__.Admin_admin_address_storage.normalize_address": {
+                "destination": "starkware.starknet.common.storage.normalize_address",
+                "type": "alias"
+            },
+            "__main__.Admin_admin_address_storage.read": {
+                "decorators": [],
+                "pc": 41,
+                "type": "function"
+            },
+            "__main__.Admin_admin_address_storage.read.Args": {
+                "full_name": "__main__.Admin_admin_address_storage.read.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.read.ImplicitArgs": {
+                "full_name": "__main__.Admin_admin_address_storage.read.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.read.Return": {
+                "cairo_type": "(admin_address : felt)",
+                "type": "type_definition"
+            },
+            "__main__.Admin_admin_address_storage.read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.Admin_admin_address_storage.storage_read": {
+                "destination": "starkware.starknet.common.syscalls.storage_read",
+                "type": "alias"
+            },
+            "__main__.Admin_admin_address_storage.storage_write": {
+                "destination": "starkware.starknet.common.syscalls.storage_write",
+                "type": "alias"
+            },
+            "__main__.Admin_admin_address_storage.write": {
+                "decorators": [],
+                "pc": 54,
+                "type": "function"
+            },
+            "__main__.Admin_admin_address_storage.write.Args": {
+                "full_name": "__main__.Admin_admin_address_storage.write.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.write.ImplicitArgs": {
+                "full_name": "__main__.Admin_admin_address_storage.write.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.Admin_admin_address_storage.write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.Admin_admin_address_storage.write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.Admin_get_admin_address": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 123,
+                "type": "function"
+            },
+            "__main__.Admin_get_admin_address.Args": {
+                "full_name": "__main__.Admin_get_admin_address.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.Admin_get_admin_address.ImplicitArgs": {
+                "full_name": "__main__.Admin_get_admin_address.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.Admin_get_admin_address.Return": {
+                "cairo_type": "(admin_address : felt)",
+                "type": "type_definition"
+            },
+            "__main__.Admin_get_admin_address.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.Admin_only_admin": {
+                "decorators": [],
+                "pc": 194,
+                "type": "function"
+            },
+            "__main__.Admin_only_admin.Args": {
+                "full_name": "__main__.Admin_only_admin.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.Admin_only_admin.ImplicitArgs": {
+                "full_name": "__main__.Admin_only_admin.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.Admin_only_admin.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.Admin_only_admin.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.Admin_set_admin_address": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 153,
+                "type": "function"
+            },
+            "__main__.Admin_set_admin_address.Args": {
+                "full_name": "__main__.Admin_set_admin_address.Args",
+                "members": {
+                    "new_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.Admin_set_admin_address.ImplicitArgs": {
+                "full_name": "__main__.Admin_set_admin_address.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.Admin_set_admin_address.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.Admin_set_admin_address.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
             "__main__.HashBuiltin": {
                 "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
                 "type": "alias"
             },
-            "__main__.alloc": {
+            "__main__.UpdatedAdminAddress": {
+                "type": "namespace"
+            },
+            "__main__.UpdatedAdminAddress.Args": {
+                "full_name": "__main__.UpdatedAdminAddress.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.UpdatedAdminAddress.ImplicitArgs": {
+                "full_name": "__main__.UpdatedAdminAddress.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.UpdatedAdminAddress.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.UpdatedAdminAddress.SELECTOR": {
+                "type": "const",
+                "value": 897086789226094900643058813354481226602860772463593146018432686653365130203
+            },
+            "__main__.UpdatedAdminAddress.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.UpdatedAdminAddress.alloc": {
                 "destination": "starkware.cairo.common.alloc.alloc",
+                "type": "alias"
+            },
+            "__main__.UpdatedAdminAddress.emit": {
+                "decorators": [],
+                "pc": 66,
+                "type": "function"
+            },
+            "__main__.UpdatedAdminAddress.emit.Args": {
+                "full_name": "__main__.UpdatedAdminAddress.emit.Args",
+                "members": {
+                    "new_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "old_admin_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.UpdatedAdminAddress.emit.ImplicitArgs": {
+                "full_name": "__main__.UpdatedAdminAddress.emit.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.UpdatedAdminAddress.emit.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.UpdatedAdminAddress.emit.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__main__.UpdatedAdminAddress.emit_event": {
+                "destination": "starkware.starknet.common.syscalls.emit_event",
+                "type": "alias"
+            },
+            "__main__.UpdatedAdminAddress.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
             "__main__.constructor": {
                 "decorators": [
                     "constructor"
                 ],
-                "pc": 133,
+                "pc": 91,
                 "type": "function"
             },
             "__main__.constructor.Args": {
                 "full_name": "__main__.constructor.Args",
                 "members": {
-                    "turn_logger_class_hash_": {
+                    "admin_address": {
                         "cairo_type": "felt",
                         "offset": 0
                     }
@@ -6358,489 +7145,111 @@
                 "type": "const",
                 "value": 0
             },
-            "__main__.deploy": {
-                "destination": "starkware.starknet.common.syscalls.deploy",
+            "__main__.get_caller_address": {
+                "destination": "starkware.starknet.common.syscalls.get_caller_address",
                 "type": "alias"
             },
-            "__main__.deploy_new_game": {
+            "__wrappers__.Admin_get_admin_address": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 138,
+                "type": "function"
+            },
+            "__wrappers__.Admin_get_admin_address.Args": {
+                "full_name": "__wrappers__.Admin_get_admin_address.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.Admin_get_admin_address.ImplicitArgs": {
+                "full_name": "__wrappers__.Admin_get_admin_address.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.Admin_get_admin_address.Return": {
+                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.Admin_get_admin_address.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.Admin_get_admin_address.__wrapped_func": {
+                "destination": "__main__.Admin_get_admin_address",
+                "type": "alias"
+            },
+            "__wrappers__.Admin_get_admin_address_encode_return": {
+                "decorators": [],
+                "pc": 129,
+                "type": "function"
+            },
+            "__wrappers__.Admin_get_admin_address_encode_return.Args": {
+                "full_name": "__wrappers__.Admin_get_admin_address_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "ret_value": {
+                        "cairo_type": "(admin_address : felt)",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__wrappers__.Admin_get_admin_address_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.Admin_get_admin_address_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.Admin_get_admin_address_encode_return.Return": {
+                "cairo_type": "(range_check_ptr : felt, data_len : felt, data : felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.Admin_get_admin_address_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 1
+            },
+            "__wrappers__.Admin_get_admin_address_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.Admin_set_admin_address": {
                 "decorators": [
                     "external"
                 ],
-                "pc": 158,
+                "pc": 176,
                 "type": "function"
             },
-            "__main__.deploy_new_game.Args": {
-                "full_name": "__main__.deploy_new_game.Args",
-                "members": {
-                    "turn_logger_address": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    }
-                },
-                "size": 1,
+            "__wrappers__.Admin_set_admin_address.Args": {
+                "full_name": "__wrappers__.Admin_set_admin_address.Args",
+                "members": {},
+                "size": 0,
                 "type": "struct"
             },
-            "__main__.deploy_new_game.ImplicitArgs": {
-                "full_name": "__main__.deploy_new_game.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 1
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 3,
+            "__wrappers__.Admin_set_admin_address.ImplicitArgs": {
+                "full_name": "__wrappers__.Admin_set_admin_address.ImplicitArgs",
+                "members": {},
+                "size": 0,
                 "type": "struct"
             },
-            "__main__.deploy_new_game.Return": {
-                "cairo_type": "()",
+            "__wrappers__.Admin_set_admin_address.Return": {
+                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
                 "type": "type_definition"
             },
-            "__main__.deploy_new_game.SIZEOF_LOCALS": {
+            "__wrappers__.Admin_set_admin_address.SIZEOF_LOCALS": {
                 "type": "const",
                 "value": 0
             },
-            "__main__.game_storage": {
-                "type": "namespace"
-            },
-            "__main__.game_storage.Args": {
-                "full_name": "__main__.game_storage.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.game_storage.HashBuiltin": {
-                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "__wrappers__.Admin_set_admin_address.__wrapped_func": {
+                "destination": "__main__.Admin_set_admin_address",
                 "type": "alias"
             },
-            "__main__.game_storage.ImplicitArgs": {
-                "full_name": "__main__.game_storage.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.game_storage.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.game_storage.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.game_storage.hash2": {
-                "destination": "starkware.cairo.common.hash.hash2",
-                "type": "alias"
-            },
-            "__main__.game_storage.normalize_address": {
-                "destination": "starkware.starknet.common.storage.normalize_address",
-                "type": "alias"
-            },
-            "__main__.game_storage.storage_read": {
-                "destination": "starkware.starknet.common.syscalls.storage_read",
-                "type": "alias"
-            },
-            "__main__.game_storage.storage_write": {
-                "destination": "starkware.starknet.common.syscalls.storage_write",
-                "type": "alias"
-            },
-            "__main__.salt": {
-                "type": "namespace"
-            },
-            "__main__.salt.Args": {
-                "full_name": "__main__.salt.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.salt.HashBuiltin": {
-                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
-                "type": "alias"
-            },
-            "__main__.salt.ImplicitArgs": {
-                "full_name": "__main__.salt.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.salt.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.salt.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.salt.addr": {
-                "decorators": [],
-                "pc": 49,
-                "type": "function"
-            },
-            "__main__.salt.addr.Args": {
-                "full_name": "__main__.salt.addr.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.salt.addr.ImplicitArgs": {
-                "full_name": "__main__.salt.addr.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 0
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.salt.addr.Return": {
-                "cairo_type": "(res : felt)",
-                "type": "type_definition"
-            },
-            "__main__.salt.addr.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.salt.hash2": {
-                "destination": "starkware.cairo.common.hash.hash2",
-                "type": "alias"
-            },
-            "__main__.salt.normalize_address": {
-                "destination": "starkware.starknet.common.storage.normalize_address",
-                "type": "alias"
-            },
-            "__main__.salt.read": {
-                "decorators": [],
-                "pc": 54,
-                "type": "function"
-            },
-            "__main__.salt.read.Args": {
-                "full_name": "__main__.salt.read.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.salt.read.ImplicitArgs": {
-                "full_name": "__main__.salt.read.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 1
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 3,
-                "type": "struct"
-            },
-            "__main__.salt.read.Return": {
-                "cairo_type": "(value : felt)",
-                "type": "type_definition"
-            },
-            "__main__.salt.read.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.salt.storage_read": {
-                "destination": "starkware.starknet.common.syscalls.storage_read",
-                "type": "alias"
-            },
-            "__main__.salt.storage_write": {
-                "destination": "starkware.starknet.common.syscalls.storage_write",
-                "type": "alias"
-            },
-            "__main__.salt.write": {
-                "decorators": [],
-                "pc": 67,
-                "type": "function"
-            },
-            "__main__.salt.write.Args": {
-                "full_name": "__main__.salt.write.Args",
-                "members": {
-                    "value": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    }
-                },
-                "size": 1,
-                "type": "struct"
-            },
-            "__main__.salt.write.ImplicitArgs": {
-                "full_name": "__main__.salt.write.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 1
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 3,
-                "type": "struct"
-            },
-            "__main__.salt.write.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.salt.write.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.turn_logger_class_hash": {
-                "type": "namespace"
-            },
-            "__main__.turn_logger_class_hash.Args": {
-                "full_name": "__main__.turn_logger_class_hash.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.HashBuiltin": {
-                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
-                "type": "alias"
-            },
-            "__main__.turn_logger_class_hash.ImplicitArgs": {
-                "full_name": "__main__.turn_logger_class_hash.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.turn_logger_class_hash.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.turn_logger_class_hash.addr": {
-                "decorators": [],
-                "pc": 79,
-                "type": "function"
-            },
-            "__main__.turn_logger_class_hash.addr.Args": {
-                "full_name": "__main__.turn_logger_class_hash.addr.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.addr.ImplicitArgs": {
-                "full_name": "__main__.turn_logger_class_hash.addr.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 0
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.addr.Return": {
-                "cairo_type": "(res : felt)",
-                "type": "type_definition"
-            },
-            "__main__.turn_logger_class_hash.addr.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.turn_logger_class_hash.hash2": {
-                "destination": "starkware.cairo.common.hash.hash2",
-                "type": "alias"
-            },
-            "__main__.turn_logger_class_hash.normalize_address": {
-                "destination": "starkware.starknet.common.storage.normalize_address",
-                "type": "alias"
-            },
-            "__main__.turn_logger_class_hash.read": {
-                "decorators": [],
-                "pc": 84,
-                "type": "function"
-            },
-            "__main__.turn_logger_class_hash.read.Args": {
-                "full_name": "__main__.turn_logger_class_hash.read.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.read.ImplicitArgs": {
-                "full_name": "__main__.turn_logger_class_hash.read.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 1
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 3,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.read.Return": {
-                "cairo_type": "(value : felt)",
-                "type": "type_definition"
-            },
-            "__main__.turn_logger_class_hash.read.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.turn_logger_class_hash.storage_read": {
-                "destination": "starkware.starknet.common.syscalls.storage_read",
-                "type": "alias"
-            },
-            "__main__.turn_logger_class_hash.storage_write": {
-                "destination": "starkware.starknet.common.syscalls.storage_write",
-                "type": "alias"
-            },
-            "__main__.turn_logger_class_hash.write": {
-                "decorators": [],
-                "pc": 97,
-                "type": "function"
-            },
-            "__main__.turn_logger_class_hash.write.Args": {
-                "full_name": "__main__.turn_logger_class_hash.write.Args",
-                "members": {
-                    "value": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    }
-                },
-                "size": 1,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.write.ImplicitArgs": {
-                "full_name": "__main__.turn_logger_class_hash.write.ImplicitArgs",
-                "members": {
-                    "pedersen_ptr": {
-                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
-                        "offset": 1
-                    },
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 3,
-                "type": "struct"
-            },
-            "__main__.turn_logger_class_hash.write.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.turn_logger_class_hash.write.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.turn_logger_contract_deployed": {
-                "type": "namespace"
-            },
-            "__main__.turn_logger_contract_deployed.Args": {
-                "full_name": "__main__.turn_logger_contract_deployed.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.turn_logger_contract_deployed.ImplicitArgs": {
-                "full_name": "__main__.turn_logger_contract_deployed.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.turn_logger_contract_deployed.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.turn_logger_contract_deployed.SELECTOR": {
-                "type": "const",
-                "value": 88834177166621382880051701260045792867089960506005798105903749384850593293
-            },
-            "__main__.turn_logger_contract_deployed.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.turn_logger_contract_deployed.alloc": {
-                "destination": "starkware.cairo.common.alloc.alloc",
-                "type": "alias"
-            },
-            "__main__.turn_logger_contract_deployed.emit": {
-                "decorators": [],
-                "pc": 109,
-                "type": "function"
-            },
-            "__main__.turn_logger_contract_deployed.emit.Args": {
-                "full_name": "__main__.turn_logger_contract_deployed.emit.Args",
-                "members": {
-                    "contract_address": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    }
-                },
-                "size": 1,
-                "type": "struct"
-            },
-            "__main__.turn_logger_contract_deployed.emit.ImplicitArgs": {
-                "full_name": "__main__.turn_logger_contract_deployed.emit.ImplicitArgs",
-                "members": {
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.turn_logger_contract_deployed.emit.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.turn_logger_contract_deployed.emit.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 2
-            },
-            "__main__.turn_logger_contract_deployed.emit_event": {
-                "destination": "starkware.starknet.common.syscalls.emit_event",
-                "type": "alias"
-            },
-            "__main__.turn_logger_contract_deployed.memcpy": {
+            "__wrappers__.Admin_set_admin_address_encode_return.memcpy": {
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
@@ -6848,7 +7257,7 @@
                 "decorators": [
                     "constructor"
                 ],
-                "pc": 140,
+                "pc": 105,
                 "type": "function"
             },
             "__wrappers__.constructor.Args": {
@@ -6876,41 +7285,6 @@
                 "type": "alias"
             },
             "__wrappers__.constructor_encode_return.memcpy": {
-                "destination": "starkware.cairo.common.memcpy.memcpy",
-                "type": "alias"
-            },
-            "__wrappers__.deploy_new_game": {
-                "decorators": [
-                    "external"
-                ],
-                "pc": 197,
-                "type": "function"
-            },
-            "__wrappers__.deploy_new_game.Args": {
-                "full_name": "__wrappers__.deploy_new_game.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__wrappers__.deploy_new_game.ImplicitArgs": {
-                "full_name": "__wrappers__.deploy_new_game.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__wrappers__.deploy_new_game.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
-                "type": "type_definition"
-            },
-            "__wrappers__.deploy_new_game.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__wrappers__.deploy_new_game.__wrapped_func": {
-                "destination": "__main__.deploy_new_game",
-                "type": "alias"
-            },
-            "__wrappers__.deploy_new_game_encode_return.memcpy": {
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
@@ -7064,58 +7438,6 @@
             "starkware.cairo.common.hash.HashBuiltin": {
                 "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
                 "type": "alias"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_ap": {
-                "decorators": [
-                    "known_ap_change"
-                ],
-                "pc": 4,
-                "type": "function"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_ap.Args": {
-                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_ap.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_ap.ImplicitArgs": {
-                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_ap.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_ap.Return": {
-                "cairo_type": "(ap_val : felt*)",
-                "type": "type_definition"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_ap.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc": {
-                "decorators": [],
-                "pc": 3,
-                "type": "function"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Args": {
-                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.ImplicitArgs": {
-                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Return": {
-                "cairo_type": "(fp_val : felt*, pc_val : felt*)",
-                "type": "type_definition"
-            },
-            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
             },
             "starkware.starknet.common.storage.ADDR_BOUND": {
                 "type": "const",
@@ -7773,79 +8095,9 @@
                 "size": 7,
                 "type": "struct"
             },
-            "starkware.starknet.common.syscalls.deploy": {
-                "decorators": [],
-                "pc": 9,
-                "type": "function"
-            },
-            "starkware.starknet.common.syscalls.deploy.Args": {
-                "full_name": "starkware.starknet.common.syscalls.deploy.Args",
-                "members": {
-                    "class_hash": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    },
-                    "constructor_calldata": {
-                        "cairo_type": "felt*",
-                        "offset": 3
-                    },
-                    "constructor_calldata_size": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "contract_address_salt": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    }
-                },
-                "size": 4,
-                "type": "struct"
-            },
-            "starkware.starknet.common.syscalls.deploy.ImplicitArgs": {
-                "full_name": "starkware.starknet.common.syscalls.deploy.ImplicitArgs",
-                "members": {
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 1,
-                "type": "struct"
-            },
-            "starkware.starknet.common.syscalls.deploy.Return": {
-                "cairo_type": "(contract_address : felt)",
-                "type": "type_definition"
-            },
-            "starkware.starknet.common.syscalls.deploy.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "starkware.starknet.common.syscalls.deploy.syscall_ptr": {
-                "cairo_type": "felt*",
-                "full_name": "starkware.starknet.common.syscalls.deploy.syscall_ptr",
-                "references": [
-                    {
-                        "ap_tracking_data": {
-                            "group": 3,
-                            "offset": 0
-                        },
-                        "pc": 9,
-                        "value": "[cast(fp + (-7), felt**)]"
-                    },
-                    {
-                        "ap_tracking_data": {
-                            "group": 3,
-                            "offset": 2
-                        },
-                        "pc": 19,
-                        "value": "cast([fp + (-7)] + 9, felt*)"
-                    }
-                ],
-                "type": "reference"
-            },
             "starkware.starknet.common.syscalls.emit_event": {
                 "decorators": [],
-                "pc": 39,
+                "pc": 26,
                 "type": "function"
             },
             "starkware.starknet.common.syscalls.emit_event.Args": {
@@ -7896,26 +8148,79 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 6,
+                            "group": 4,
                             "offset": 0
                         },
-                        "pc": 39,
+                        "pc": 26,
                         "value": "[cast(fp + (-7), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 6,
+                            "group": 4,
                             "offset": 1
                         },
-                        "pc": 46,
+                        "pc": 33,
                         "value": "cast([fp + (-7)] + 5, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.get_caller_address": {
+                "decorators": [],
+                "pc": 3,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.get_caller_address.Args": {
+                "full_name": "starkware.starknet.common.syscalls.get_caller_address.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.get_caller_address.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.get_caller_address.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.get_caller_address.Return": {
+                "cairo_type": "(caller_address : felt)",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.get_caller_address.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 0
+                        },
+                        "pc": 3,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 1
+                        },
+                        "pc": 6,
+                        "value": "cast([fp + (-3)] + 2, felt*)"
                     }
                 ],
                 "type": "reference"
             },
             "starkware.starknet.common.syscalls.storage_read": {
                 "decorators": [],
-                "pc": 23,
+                "pc": 10,
                 "type": "function"
             },
             "starkware.starknet.common.syscalls.storage_read.Args": {
@@ -7954,18 +8259,18 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 4,
+                            "group": 2,
                             "offset": 0
                         },
-                        "pc": 23,
+                        "pc": 10,
                         "value": "[cast(fp + (-4), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 4,
+                            "group": 2,
                             "offset": 1
                         },
-                        "pc": 27,
+                        "pc": 14,
                         "value": "cast([fp + (-4)] + 3, felt*)"
                     }
                 ],
@@ -7973,7 +8278,7 @@
             },
             "starkware.starknet.common.syscalls.storage_write": {
                 "decorators": [],
-                "pc": 31,
+                "pc": 18,
                 "type": "function"
             },
             "starkware.starknet.common.syscalls.storage_write.Args": {
@@ -8016,18 +8321,18 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 5,
+                            "group": 3,
                             "offset": 0
                         },
-                        "pc": 31,
+                        "pc": 18,
                         "value": "[cast(fp + (-5), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 5,
+                            "group": 3,
                             "offset": 1
                         },
-                        "pc": 36,
+                        "pc": 23,
                         "value": "cast([fp + (-5)] + 3, felt*)"
                     }
                 ],
@@ -8040,34 +8345,34 @@
             "references": [
                 {
                     "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 10,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
                         "group": 3,
                         "offset": 0
                     },
-                    "pc": 9,
-                    "value": "[cast(fp + (-7), felt**)]"
+                    "pc": 18,
+                    "value": "[cast(fp + (-5), felt**)]"
                 },
                 {
                     "ap_tracking_data": {
                         "group": 4,
                         "offset": 0
                     },
-                    "pc": 23,
-                    "value": "[cast(fp + (-4), felt**)]"
-                },
-                {
-                    "ap_tracking_data": {
-                        "group": 5,
-                        "offset": 0
-                    },
-                    "pc": 31,
-                    "value": "[cast(fp + (-5), felt**)]"
-                },
-                {
-                    "ap_tracking_data": {
-                        "group": 6,
-                        "offset": 0
-                    },
-                    "pc": 39,
+                    "pc": 26,
                     "value": "[cast(fp + (-7), felt**)]"
                 }
             ]

--- a/contracts/turn_logger/abi/game_factory_abi.json
+++ b/contracts/turn_logger/abi/game_factory_abi.json
@@ -1,0 +1,35 @@
+[
+    {
+        "data": [
+            {
+                "name": "contract_address",
+                "type": "felt"
+            }
+        ],
+        "keys": [],
+        "name": "administered_contract_deployed",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "name": "admin_class_hash_",
+                "type": "felt"
+            }
+        ],
+        "name": "constructor",
+        "outputs": [],
+        "type": "constructor"
+    },
+    {
+        "inputs": [
+            {
+                "name": "admin_address",
+                "type": "felt"
+            }
+        ],
+        "name": "deploy_new_game",
+        "outputs": [],
+        "type": "function"
+    }
+]

--- a/contracts/turn_logger/abi/game_factory_abi.json
+++ b/contracts/turn_logger/abi/game_factory_abi.json
@@ -7,13 +7,13 @@
             }
         ],
         "keys": [],
-        "name": "administered_contract_deployed",
+        "name": "turn_logger_contract_deployed",
         "type": "event"
     },
     {
         "inputs": [
             {
-                "name": "admin_class_hash_",
+                "name": "turn_logger_class_hash_",
                 "type": "felt"
             }
         ],
@@ -24,7 +24,7 @@
     {
         "inputs": [
             {
-                "name": "admin_address",
+                "name": "turn_logger_address",
                 "type": "felt"
             }
         ],

--- a/contracts/turn_logger/game_factory.cairo
+++ b/contracts/turn_logger/game_factory.cairo
@@ -13,7 +13,11 @@ func salt() -> (value : felt):
 end
 
 @storage_var
-func admin_class_hash() -> (value : felt):
+func turn_logger_class_hash() -> (value : felt):
+end
+
+@storage_var
+func game_storage(index : felt) -> (contract_address : felt):
 end
 
 #
@@ -21,7 +25,7 @@ end
 #
 
 @event
-func administered_contract_deployed(contract_address : felt):
+func turn_logger_contract_deployed(contract_address : felt):
 end
 
 #
@@ -33,8 +37,8 @@ func constructor{
     syscall_ptr : felt*,
     pedersen_ptr : HashBuiltin*,
     range_check_ptr,
-}(admin_class_hash_ : felt):
-    admin_class_hash.write(value=admin_class_hash_)
+}(turn_logger_class_hash_ : felt):
+    turn_logger_class_hash.write(value=turn_logger_class_hash_)
     return ()
 end
 
@@ -47,18 +51,18 @@ func deploy_new_game{
     syscall_ptr : felt*, 
     pedersen_ptr : HashBuiltin*, 
     range_check_ptr
-    }(admin_address : felt):
+    }(turn_logger_address : felt):
         let (current_salt) = salt.read()
-        let (class_hash) = admin_class_hash.read()
+        let (class_hash) = turn_logger_class_hash.read()
         let (contract_address) = deploy(
             class_hash=class_hash,
             contract_address_salt=current_salt,
             constructor_calldata_size=1,
-            constructor_calldata=cast(new (admin_address,), felt*),
+            constructor_calldata=cast(new (turn_logger_address,), felt*),
         )
         salt.write(value=current_salt + 1)
 
-        administered_contract_deployed.emit(
+        turn_logger_contract_deployed.emit(
             contract_address=contract_address
         )
         return ()

--- a/contracts/turn_logger/game_factory.cairo
+++ b/contracts/turn_logger/game_factory.cairo
@@ -1,0 +1,65 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import deploy
+
+#
+# Storage Variables
+#
+
+@storage_var
+func salt() -> (value : felt):
+end
+
+@storage_var
+func admin_class_hash() -> (value : felt):
+end
+
+#
+# Events
+#
+
+@event
+func administered_contract_deployed(contract_address : felt):
+end
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+    syscall_ptr : felt*,
+    pedersen_ptr : HashBuiltin*,
+    range_check_ptr,
+}(admin_class_hash_ : felt):
+    admin_class_hash.write(value=admin_class_hash_)
+    return ()
+end
+
+#
+# External
+#
+
+@external
+func deploy_new_game{
+    syscall_ptr : felt*, 
+    pedersen_ptr : HashBuiltin*, 
+    range_check_ptr
+    }(admin_address : felt):
+        let (current_salt) = salt.read()
+        let (class_hash) = admin_class_hash.read()
+        let (contract_address) = deploy(
+            class_hash=class_hash,
+            contract_address_salt=current_salt,
+            constructor_calldata_size=1,
+            constructor_calldata=cast(new (admin_address,), felt*),
+        )
+        salt.write(value=current_salt + 1)
+
+        administered_contract_deployed.emit(
+            contract_address=contract_address
+        )
+        return ()
+end

--- a/contracts/turn_logger/library.cairo
+++ b/contracts/turn_logger/library.cairo
@@ -1,3 +1,7 @@
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address, get_block_timestamp
+
 # This should work on validating rounds and saying who died each day
 
 # Assign roles, or don't? Figure out who won?

--- a/contracts/turn_logger/library.cairo
+++ b/contracts/turn_logger/library.cairo
@@ -3,3 +3,73 @@
 # Assign roles, or don't? Figure out who won?
 
 
+#FLOW
+#D0 ---> N1 ---> D1 ---> N2 ----> D2
+
+#Build for arbritrary Game of 8-12 
+#Jester. Executioner. Invest. Three other two. Two-three mobsters. 
+
+
+#Roles help include win conditions and choose who won at end? Instead of having game terminate at whatever
+
+#Is will writing managed here or in account? Is role managed here or in account?
+#Role management needs to be handled like address-->name--> role. Is there a way to anonymize this?
+#Have it be the hashed address is the only way to call it, but you'll see what the address calling it is (who the account is)
+#Could it be that you have address passed in with a random prime off chain determines returns on_chain name, but you'd never see
+#and address pased in with different random prime off chain returns role? But do you see in the explorer who that is?
+#What about shipping first. Thinking about anonymity at the end
+
+#
+# Events
+#
+
+@events
+func WinnerDeclared(day : felt, role : felt, winner : felt):
+end 
+
+#
+# Storage
+#
+
+@storage_var
+func character_will_storage(address : felt) -> (will : WillStruct):
+end
+
+##require a with attr asser that caller sender is the person will holder
+#ohh something that might be useful to help anonymize things is the frontend can handle resolving 
+#account addresses to names. And that way they couldn't figure out who is who except by cross-referencing
+#addr and name. That is acceptable IMO for the interim
+
+
+#
+# Constructor
+#
+
+#Initialize an only admin for these cases. Deploy new contracts if need be to set up the game.
+#Find a way to clear everything at the end (feature) or keep everything forever on chain?
+
+
+
+#
+# Getters; pull ABI objects on time? 
+#
+
+#Figure out how many people are still alive. 
+#Recieve the nightly death
+#Recieve the nightly hannging. 
+#Can store will's so they persist between rounds
+    #Hash the name as an indentifier
+
+
+#
+# Setters; set the key 
+#
+
+
+#
+# Business Logic 
+#
+
+
+#OnlyAdmin() callable function that checks if game is over. At the end of the game based on what is happening
+#Then figure out if a win condition is reached. The client is runs the Admin account and checks

--- a/contracts/turn_logger/library.cairo
+++ b/contracts/turn_logger/library.cairo
@@ -1,0 +1,5 @@
+# This should work on validating rounds and saying who died each day
+
+# Assign roles, or don't? Figure out who won?
+
+

--- a/contracts/turn_logger/output/game_factory_compiled.json
+++ b/contracts/turn_logger/output/game_factory_compiled.json
@@ -1,0 +1,8033 @@
+{
+    "abi": [
+        {
+            "data": [
+                {
+                    "name": "contract_address",
+                    "type": "felt"
+                }
+            ],
+            "keys": [],
+            "name": "administered_contract_deployed",
+            "type": "event"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "admin_class_hash_",
+                    "type": "felt"
+                }
+            ],
+            "name": "constructor",
+            "outputs": [],
+            "type": "constructor"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "admin_address",
+                    "type": "felt"
+                }
+            ],
+            "name": "deploy_new_game",
+            "outputs": [],
+            "type": "function"
+        }
+    ],
+    "entry_points_by_type": {
+        "CONSTRUCTOR": [
+            {
+                "offset": "0x8c",
+                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+            }
+        ],
+        "EXTERNAL": [
+            {
+                "offset": "0xc5",
+                "selector": "0x836f0191f38692b29488890228b54a1d221c344a4a3624a20045883227507e"
+            }
+        ],
+        "L1_HANDLER": []
+    },
+    "program": {
+        "attributes": [],
+        "builtins": [
+            "pedersen",
+            "range_check"
+        ],
+        "data": [
+            "0x40780017fff7fff",
+            "0x1",
+            "0x208b7fff7fff7ffe",
+            "0x208b7fff7fff7ffe",
+            "0x1104800180018000",
+            "0x800000000000011000000000000000000000000000000000000000000000000",
+            "0x482480017ffe8000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffff",
+            "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x4465706c6f79",
+            "0x400280007ff97fff",
+            "0x400380017ff97ffa",
+            "0x400380027ff97ffb",
+            "0x400380037ff97ffc",
+            "0x400380047ff97ffd",
+            "0x480680017fff8000",
+            "0x0",
+            "0x400280057ff97fff",
+            "0x482680017ff98000",
+            "0x9",
+            "0x480280067ff98000",
+            "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x53746f7261676552656164",
+            "0x400280007ffc7fff",
+            "0x400380017ffc7ffd",
+            "0x482680017ffc8000",
+            "0x3",
+            "0x480280027ffc8000",
+            "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x53746f726167655772697465",
+            "0x400280007ffb7fff",
+            "0x400380017ffb7ffc",
+            "0x400380027ffb7ffd",
+            "0x482680017ffb8000",
+            "0x3",
+            "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x456d69744576656e74",
+            "0x400280007ff97fff",
+            "0x400380017ff97ffa",
+            "0x400380027ff97ffb",
+            "0x400380037ff97ffc",
+            "0x400380047ff97ffd",
+            "0x482680017ff98000",
+            "0x5",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x480680017fff8000",
+            "0x5e334153147e75f3f416139b5109d1179cb56fef6a4ecb4c4cbc92a7c37b70",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
+            "0x480a7ffb7fff8000",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdc",
+            "0x48127ffe7fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ffc7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+            "0x480a7ffa7fff8000",
+            "0x48127ffe7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd6",
+            "0x48127ff67fff8000",
+            "0x48127ff67fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x480680017fff8000",
+            "0x248077f862fc0affc664970be050f31d245a91d8a723f9d58bea04613816f0e",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
+            "0x480a7ffb7fff8000",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbe",
+            "0x48127ffe7fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ffc7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+            "0x480a7ffa7fff8000",
+            "0x48127ffe7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb8",
+            "0x48127ff67fff8000",
+            "0x48127ff67fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x2",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff92",
+            "0x40137fff7fff8000",
+            "0x480680017fff8000",
+            "0x276319dfbf8bcddae53da7dcd10a745420bd1793ac38b184c8799d03c9cb76d",
+            "0x4002800080007fff",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8c",
+            "0x40137fff7fff8001",
+            "0x4003800080017ffd",
+            "0x4826800180018000",
+            "0x1",
+            "0x480a7ffb7fff8000",
+            "0x480680017fff8000",
+            "0x1",
+            "0x480a80007fff8000",
+            "0x4828800180007ffc",
+            "0x480a80017fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffa7",
+            "0x480a7ffc7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd9",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff3",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff96",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffaf",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff5c",
+            "0x482480017fff8000",
+            "0x800000000000011000000000000000000000000000000000000000000000000",
+            "0x48127ff57fff8000",
+            "0x48127ff77fff8000",
+            "0x48127fdf7fff8000",
+            "0x480680017fff8000",
+            "0x1",
+            "0x48127ffb7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff57",
+            "0x48127ffe7fff8000",
+            "0x48127fea7fff8000",
+            "0x48127fea7fff8000",
+            "0x482480017fd38000",
+            "0x1",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8a",
+            "0x48127ffd7fff8000",
+            "0x48127ffe7fff8000",
+            "0x48127fe77fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffaf",
+            "0x48127ffe7fff8000",
+            "0x48127fe47fff8000",
+            "0x48127ffd7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd3",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe"
+        ],
+        "debug_info": {
+            "file_contents": {
+                "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo": "assert [cast(fp + (-4), felt*)] = __calldata_actual_size\n",
+                "autogen/starknet/arg_processor/26f15a9c5452d70e4cc375617f10b6116f9f34527dec544e7a83bf3f2d0d94a6.cairo": "assert [__calldata_ptr] = contract_address\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/arg_processor/27d65e22afd387c553257865fda7dde17a4db80afb5634cb6d7fbf8ba379f5f1.cairo": "let __calldata_arg_admin_class_hash_ = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo": "let __calldata_actual_size =  __calldata_ptr - cast([cast(fp + (-3), felt**)], felt*)\n",
+                "autogen/starknet/arg_processor/c8f8e2249de7b41049de03cb248003121a3f9d075aa868b48f0168d146fac255.cairo": "let __calldata_arg_admin_address = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
+                "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
+                "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
+                "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/external/constructor/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
+                "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
+                "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(admin_class_hash_=__calldata_arg_admin_class_hash_,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
+                "autogen/starknet/external/constructor/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
+                "autogen/starknet/external/constructor/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
+                "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(admin_address=__calldata_arg_admin_address,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
+                "autogen/starknet/external/deploy_new_game/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
+                "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
+                "autogen/starknet/external/deploy_new_game/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
+                "autogen/starknet/external/deploy_new_game/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
+                "autogen/starknet/storage_var/admin_class_hash/decl.cairo": "namespace admin_class_hash:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
+                "autogen/starknet/storage_var/admin_class_hash/impl.cairo": "namespace admin_class_hash:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 1031890436099722109475719470914077542574177270140737693609855966487959924494\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend",
+                "autogen/starknet/storage_var/salt/decl.cairo": "namespace salt:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
+                "autogen/starknet/storage_var/salt/impl.cairo": "namespace salt:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 166437374298738756398629469846363953049641320050310028217330679862127721328\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        value : felt\n    ):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend"
+            },
+            "instruction_locations": {
+                "0": {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.alloc",
+                        "starkware.cairo.common.alloc.alloc"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 38,
+                                "end_line": 3,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/common/alloc.cairo"
+                                },
+                                "start_col": 5,
+                                "start_line": 3
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 12,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/common/alloc.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 4
+                    }
+                },
+                "2": {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.alloc",
+                        "starkware.cairo.common.alloc.alloc"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 39,
+                        "end_line": 5,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/common/alloc.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 5
+                    }
+                },
+                "3": {
+                    "accessible_scopes": [
+                        "starkware.cairo.lang.compiler.lib.registers",
+                        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 72,
+                        "end_line": 6,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 6
+                    }
+                },
+                "4": {
+                    "accessible_scopes": [
+                        "starkware.cairo.lang.compiler.lib.registers",
+                        "starkware.cairo.lang.compiler.lib.registers.get_ap"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 43,
+                        "end_line": 15,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                        },
+                        "start_col": 28,
+                        "start_line": 15
+                    }
+                },
+                "6": {
+                    "accessible_scopes": [
+                        "starkware.cairo.lang.compiler.lib.registers",
+                        "starkware.cairo.lang.compiler.lib.registers.get_ap"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                        },
+                        "start_col": 20,
+                        "start_line": 16
+                    }
+                },
+                "8": {
+                    "accessible_scopes": [
+                        "starkware.cairo.lang.compiler.lib.registers",
+                        "starkware.cairo.lang.compiler.lib.registers.get_ap"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 31,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 16
+                    }
+                },
+                "9": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 33,
+                        "end_line": 161,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 18,
+                        "start_line": 161
+                    }
+                },
+                "11": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 160
+                    }
+                },
+                "12": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 160
+                    }
+                },
+                "13": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 160
+                    }
+                },
+                "14": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 160
+                    }
+                },
+                "15": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 160
+                    }
+                },
+                "16": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 19,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 18,
+                        "start_line": 166
+                    }
+                },
+                "18": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 166,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 160
+                    }
+                },
+                "19": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 81,
+                                "end_line": 168,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "start_col": 5,
+                                "start_line": 168
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 48,
+                        "end_line": 170,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 32,
+                                "end_line": 153,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 56,
+                                        "end_line": 172,
+                                        "input_file": {
+                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 172
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 13,
+                                "start_line": 153
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 170
+                    }
+                },
+                "21": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 55,
+                        "end_line": 172,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 172
+                    }
+                },
+                "22": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 56,
+                        "end_line": 172,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 172
+                    }
+                },
+                "23": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 79,
+                        "end_line": 348,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 58,
+                        "start_line": 348
+                    }
+                },
+                "25": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 97,
+                        "end_line": 348,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 348
+                    }
+                },
+                "26": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 97,
+                        "end_line": 348,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 348
+                    }
+                },
+                "27": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 87,
+                                "end_line": 349,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "start_col": 5,
+                                "start_line": 349
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 53,
+                        "end_line": 351,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 38,
+                                "end_line": 346,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 34,
+                                        "end_line": 352,
+                                        "input_file": {
+                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 352
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 19,
+                                "start_line": 346
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 351
+                    }
+                },
+                "29": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 33,
+                        "end_line": 352,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 19,
+                        "start_line": 352
+                    }
+                },
+                "30": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 352,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 352
+                    }
+                },
+                "31": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 40,
+                        "end_line": 366,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 18,
+                        "start_line": 366
+                    }
+                },
+                "33": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 366,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 365
+                    }
+                },
+                "34": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 366,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 365
+                    }
+                },
+                "35": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 366,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 365
+                    }
+                },
+                "36": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 88,
+                                "end_line": 367,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "start_col": 5,
+                                "start_line": 367
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 54,
+                        "end_line": 368,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 39,
+                                "end_line": 364,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 14,
+                                        "end_line": 369,
+                                        "input_file": {
+                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 369
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 20,
+                                "start_line": 364
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 368
+                    }
+                },
+                "38": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 14,
+                        "end_line": 369,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 369
+                    }
+                },
+                "39": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 37,
+                        "end_line": 385,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 18,
+                        "start_line": 385
+                    }
+                },
+                "41": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 98,
+                        "end_line": 385,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 384
+                    }
+                },
+                "42": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 98,
+                        "end_line": 385,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 384
+                    }
+                },
+                "43": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 98,
+                        "end_line": 385,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 384
+                    }
+                },
+                "44": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 98,
+                        "end_line": 385,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 384
+                    }
+                },
+                "45": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 98,
+                        "end_line": 385,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 384
+                    }
+                },
+                "46": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 85,
+                                "end_line": 386,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "start_col": 5,
+                                "start_line": 386
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 51,
+                        "end_line": 387,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 383,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 14,
+                                        "end_line": 388,
+                                        "input_file": {
+                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 388
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 17,
+                                "start_line": 383
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 387
+                    }
+                },
+                "48": {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 14,
+                        "end_line": 388,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 388
+                    }
+                },
+                "49": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 25,
+                                        "end_line": 9,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 9
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "50": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 25,
+                                        "end_line": 9,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 9
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "51": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 94,
+                        "end_line": 8,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 24,
+                                "end_line": 9,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "start_col": 21,
+                                "start_line": 9
+                            },
+                            "While expanding the reference 'res' in:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 8
+                    }
+                },
+                "53": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 25,
+                        "end_line": 9,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 9
+                    }
+                },
+                "54": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 12,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 15,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 15
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 12
+                    }
+                },
+                "55": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 12,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 15,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 15
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 12
+                    }
+                },
+                "56": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 36,
+                        "end_line": 15,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 15
+                    }
+                },
+                "58": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 12,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 38,
+                                "end_line": 346,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 75,
+                                        "end_line": 16,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 37,
+                                        "start_line": 16
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 19,
+                                "start_line": 346
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 12
+                    }
+                },
+                "59": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 26,
+                        "end_line": 15,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 70,
+                                "end_line": 16,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "start_col": 58,
+                                "start_line": 16
+                            },
+                            "While expanding the reference 'storage_addr' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 15
+                    }
+                },
+                "60": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 75,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 37,
+                        "start_line": 16
+                    }
+                },
+                "62": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 38,
+                        "end_line": 346,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 75,
+                                "end_line": 16,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 42,
+                                        "end_line": 18,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 31,
+                                        "start_line": 18
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 37,
+                                "start_line": 16
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 346
+                    }
+                },
+                "63": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 15,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 44,
+                                        "end_line": 19,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 32,
+                                        "start_line": 19
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 15
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "64": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 15,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 50,
+                                        "end_line": 20,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 35,
+                                        "start_line": 20
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 15
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "65": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 33,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 65,
+                                "end_line": 21,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "start_col": 46,
+                                "start_line": 21
+                            },
+                            "While expanding the reference '__storage_var_temp0' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 16
+                    }
+                },
+                "66": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 53,
+                        "end_line": 22,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 22
+                    }
+                },
+                "67": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 26,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 26
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 37,
+                        "start_line": 25
+                    }
+                },
+                "68": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 81,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 26,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 26
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 66,
+                        "start_line": 25
+                    }
+                },
+                "69": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 36,
+                        "end_line": 26,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 26
+                    }
+                },
+                "71": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 35,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 39,
+                                "end_line": 364,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 80,
+                                        "end_line": 27,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 27
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 20,
+                                "start_line": 364
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 16,
+                        "start_line": 25
+                    }
+                },
+                "72": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 26,
+                        "end_line": 26,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 43,
+                                "end_line": 27,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "start_col": 31,
+                                "start_line": 27
+                            },
+                            "While expanding the reference 'storage_addr' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 26
+                    }
+                },
+                "73": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 79,
+                        "end_line": 27,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 55,
+                        "start_line": 27
+                    }
+                },
+                "74": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 27,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 27
+                    }
+                },
+                "76": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 26,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 28,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 28
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 37,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 26
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "77": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 26,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 81,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 28,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 28
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 66,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 26
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "78": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.salt",
+                        "__main__.salt.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 18,
+                        "end_line": 28,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 28
+                    }
+                },
+                "79": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 25,
+                                        "end_line": 9,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 9
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "80": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 25,
+                                        "end_line": 9,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 9
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "81": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 95,
+                        "end_line": 8,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 24,
+                                "end_line": 9,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "start_col": 21,
+                                "start_line": 9
+                            },
+                            "While expanding the reference 'res' in:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 8
+                    }
+                },
+                "83": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.addr"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 25,
+                        "end_line": 9,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 9
+                    }
+                },
+                "84": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 12,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 15,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 15
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 12
+                    }
+                },
+                "85": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 12,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 15,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 15
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 12
+                    }
+                },
+                "86": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 36,
+                        "end_line": 15,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 15
+                    }
+                },
+                "88": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 12,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 38,
+                                "end_line": 346,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 75,
+                                        "end_line": 16,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 37,
+                                        "start_line": 16
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 19,
+                                "start_line": 346
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 12
+                    }
+                },
+                "89": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 26,
+                        "end_line": 15,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 70,
+                                "end_line": 16,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "start_col": 58,
+                                "start_line": 16
+                            },
+                            "While expanding the reference 'storage_addr' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 15
+                    }
+                },
+                "90": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 75,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 37,
+                        "start_line": 16
+                    }
+                },
+                "92": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 38,
+                        "end_line": 346,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 75,
+                                "end_line": 16,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 42,
+                                        "end_line": 18,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 31,
+                                        "start_line": 18
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 37,
+                                "start_line": 16
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 346
+                    }
+                },
+                "93": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 15,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 44,
+                                        "end_line": 19,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 32,
+                                        "start_line": 19
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 15
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "94": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 15,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 50,
+                                        "end_line": 20,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 35,
+                                        "start_line": 20
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 15
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "95": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 33,
+                        "end_line": 16,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 65,
+                                "end_line": 21,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "start_col": 46,
+                                "start_line": 21
+                            },
+                            "While expanding the reference '__storage_var_temp0' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 16
+                    }
+                },
+                "96": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.read"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 53,
+                        "end_line": 22,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 22
+                    }
+                },
+                "97": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 42,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 26,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 26
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 37,
+                        "start_line": 25
+                    }
+                },
+                "98": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 81,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 59,
+                                "end_line": 7,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 26,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 26
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 44,
+                                "start_line": 7
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 66,
+                        "start_line": 25
+                    }
+                },
+                "99": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 36,
+                        "end_line": 26,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 26
+                    }
+                },
+                "101": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 35,
+                        "end_line": 25,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 39,
+                                "end_line": 364,
+                                "input_file": {
+                                    "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 80,
+                                        "end_line": 27,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                        },
+                                        "start_col": 9,
+                                        "start_line": 27
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 20,
+                                "start_line": 364
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 16,
+                        "start_line": 25
+                    }
+                },
+                "102": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 26,
+                        "end_line": 26,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 43,
+                                "end_line": 27,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "start_col": 31,
+                                "start_line": 27
+                            },
+                            "While expanding the reference 'storage_addr' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 26
+                    }
+                },
+                "103": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 79,
+                        "end_line": 27,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 55,
+                        "start_line": 27
+                    }
+                },
+                "104": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 27,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 27
+                    }
+                },
+                "106": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 26,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 28,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 28
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 37,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 26
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 7
+                    }
+                },
+                "107": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 59,
+                        "end_line": 7,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 26,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 81,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 28,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 28
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 66,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 26
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 7
+                    }
+                },
+                "108": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.admin_class_hash",
+                        "__main__.admin_class_hash.write"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 18,
+                        "end_line": 28,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 28
+                    }
+                },
+                "109": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 13,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "111": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 41,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 34,
+                        "start_line": 2
+                    }
+                },
+                "113": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 6,
+                        "start_line": 2
+                    }
+                },
+                "114": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 31,
+                        "end_line": 3,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 3
+                    }
+                },
+                "116": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 31,
+                        "end_line": 3,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 3
+                    }
+                },
+                "117": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 41,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 34,
+                        "start_line": 4
+                    }
+                },
+                "119": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 6,
+                        "start_line": 4
+                    }
+                },
+                "120": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 43,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/26f15a9c5452d70e4cc375617f10b6116f9f34527dec544e7a83bf3f2d0d94a6.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 53,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 37,
+                                "start_line": 24
+                            },
+                            "While handling calldata argument 'contract_address'"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "121": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 40,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/26f15a9c5452d70e4cc375617f10b6116f9f34527dec544e7a83bf3f2d0d94a6.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 53,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 36,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 50,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_ptr' in:"
+                                ],
+                                "start_col": 37,
+                                "start_line": 24
+                            },
+                            "While handling calldata argument 'contract_address'"
+                        ],
+                        "start_col": 22,
+                        "start_line": 2
+                    }
+                },
+                "123": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 36,
+                                        "end_line": 383,
+                                        "input_file": {
+                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 95,
+                                                "end_line": 1,
+                                                "input_file": {
+                                                    "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 36,
+                                                        "end_line": 24,
+                                                        "input_file": {
+                                                            "filename": "game_factory.cairo"
+                                                        },
+                                                        "start_col": 6,
+                                                        "start_line": 24
+                                                    },
+                                                    "While handling event:"
+                                                ],
+                                                "start_col": 1,
+                                                "start_line": 1
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 17,
+                                        "start_line": 383
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 11,
+                        "start_line": 1
+                    }
+                },
+                "124": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 22,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 21,
+                        "start_line": 1
+                    }
+                },
+                "126": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 22,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 39,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 36,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 29,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__keys_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 12,
+                        "start_line": 2
+                    }
+                },
+                "127": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 77,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 50,
+                        "start_line": 1
+                    }
+                },
+                "128": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 22,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 94,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 36,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 84,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__data_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 12,
+                        "start_line": 4
+                    }
+                },
+                "129": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 95,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "131": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 47,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 47,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 36,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 10,
+                                                        "end_line": 2,
+                                                        "input_file": {
+                                                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                        },
+                                                        "parent_location": [
+                                                            {
+                                                                "end_col": 36,
+                                                                "end_line": 24,
+                                                                "input_file": {
+                                                                    "filename": "game_factory.cairo"
+                                                                },
+                                                                "start_col": 6,
+                                                                "start_line": 24
+                                                            },
+                                                            "While handling event:"
+                                                        ],
+                                                        "start_col": 1,
+                                                        "start_line": 2
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 32,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 32,
+                        "start_line": 1
+                    }
+                },
+                "132": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__.administered_contract_deployed",
+                        "__main__.administered_contract_deployed.emit"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 10,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 2
+                    }
+                },
+                "133": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 24,
+                        "end_line": 33,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 35,
+                                "end_line": 21,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 52,
+                                        "end_line": 37,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 37
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 16,
+                                "start_line": 21
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 5,
+                        "start_line": 33
+                    }
+                },
+                "134": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 32,
+                        "end_line": 34,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 64,
+                                "end_line": 21,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 52,
+                                        "end_line": 37,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 37
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 37,
+                                "start_line": 21
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 5,
+                        "start_line": 34
+                    }
+                },
+                "135": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 35,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 81,
+                                "end_line": 21,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 52,
+                                        "end_line": 37,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 5,
+                                        "start_line": 37
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 66,
+                                "start_line": 21
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 5,
+                        "start_line": 35
+                    }
+                },
+                "136": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 27,
+                        "end_line": 36,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 37,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 34,
+                                "start_line": 37
+                            },
+                            "While expanding the reference 'admin_class_hash_' in:"
+                        ],
+                        "start_col": 3,
+                        "start_line": 36
+                    }
+                },
+                "137": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 52,
+                        "end_line": 37,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 37
+                    }
+                },
+                "139": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 14,
+                        "end_line": 38,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 38
+                    }
+                },
+                "140": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 40,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/27d65e22afd387c553257865fda7dde17a4db80afb5634cb6d7fbf8ba379f5f1.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 27,
+                                "end_line": 36,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 45,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 57,
+                                                        "end_line": 1,
+                                                        "input_file": {
+                                                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                                                        },
+                                                        "parent_location": [
+                                                            {
+                                                                "end_col": 17,
+                                                                "end_line": 32,
+                                                                "input_file": {
+                                                                    "filename": "game_factory.cairo"
+                                                                },
+                                                                "start_col": 6,
+                                                                "start_line": 32
+                                                            },
+                                                            "While handling calldata of"
+                                                        ],
+                                                        "start_col": 35,
+                                                        "start_line": 1
+                                                    },
+                                                    "While expanding the reference '__calldata_actual_size' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While handling calldata of"
+                                        ],
+                                        "start_col": 31,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_ptr' in:"
+                                ],
+                                "start_col": 3,
+                                "start_line": 36
+                            },
+                            "While handling calldata argument 'admin_class_hash_'"
+                        ],
+                        "start_col": 22,
+                        "start_line": 2
+                    }
+                },
+                "142": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 57,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While handling calldata of"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "143": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 24,
+                                "end_line": 33,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 55,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 44,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 33
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 1
+                    }
+                },
+                "144": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 110,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 32,
+                                "end_line": 34,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 82,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 70,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 34
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 20,
+                        "start_line": 1
+                    }
+                },
+                "145": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 67,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 20,
+                                "end_line": 35,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 115,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 100,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 35
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 1
+                    }
+                },
+                "146": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 56,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/27d65e22afd387c553257865fda7dde17a4db80afb5634cb6d7fbf8ba379f5f1.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 27,
+                                "end_line": 36,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 167,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 135,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_arg_admin_class_hash_' in:"
+                                ],
+                                "start_col": 3,
+                                "start_line": 36
+                            },
+                            "While handling calldata argument 'admin_class_hash_'"
+                        ],
+                        "start_col": 40,
+                        "start_line": 1
+                    }
+                },
+                "147": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 17,
+                        "end_line": 32,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 32
+                    }
+                },
+                "149": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 34,
+                                "end_line": 2,
+                                "input_file": {
+                                    "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 17,
+                                        "end_line": 32,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 6,
+                                        "start_line": 32
+                                    },
+                                    "While constructing the external wrapper for:"
+                                ],
+                                "start_col": 1,
+                                "start_line": 2
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 24,
+                        "end_line": 3,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 3
+                    }
+                },
+                "151": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 55,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 20,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 9,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 1
+                    }
+                },
+                "152": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 82,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 33,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 21,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 70,
+                        "start_line": 1
+                    }
+                },
+                "153": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 115,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 49,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 34,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 100,
+                        "start_line": 1
+                    }
+                },
+                "154": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 21,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 62,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 50,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'retdata_size' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 20,
+                        "start_line": 4
+                    }
+                },
+                "156": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 16,
+                        "end_line": 3,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/5b87af4d6ab2f5413d215eb3f6eebfed8fc7c4846d872b26a79b11167243526d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 70,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 17,
+                                                "end_line": 32,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 32
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 63,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'retdata' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 9,
+                        "start_line": 3
+                    }
+                },
+                "157": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 17,
+                                "end_line": 32,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 32
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "158": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 24,
+                        "end_line": 47,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 34,
+                                "end_line": 13,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 41,
+                                        "end_line": 51,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 51
+                                    },
+                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                ],
+                                "start_col": 15,
+                                "start_line": 13
+                            },
+                            "While expanding the reference 'syscall_ptr' in:"
+                        ],
+                        "start_col": 5,
+                        "start_line": 47
+                    }
+                },
+                "159": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 32,
+                        "end_line": 48,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 63,
+                                "end_line": 13,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 41,
+                                        "end_line": 51,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 51
+                                    },
+                                    "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 36,
+                                "start_line": 13
+                            },
+                            "While expanding the reference 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 5,
+                        "start_line": 48
+                    }
+                },
+                "160": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 20,
+                        "end_line": 49,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 80,
+                                "end_line": 13,
+                                "input_file": {
+                                    "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 41,
+                                        "end_line": 51,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 30,
+                                        "start_line": 51
+                                    },
+                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                ],
+                                "start_col": 65,
+                                "start_line": 13
+                            },
+                            "While expanding the reference 'range_check_ptr' in:"
+                        ],
+                        "start_col": 5,
+                        "start_line": 49
+                    }
+                },
+                "161": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 41,
+                        "end_line": 51,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 30,
+                        "start_line": 51
+                    }
+                },
+                "163": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 41,
+                                "end_line": 51,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 34,
+                                        "end_line": 13,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 51,
+                                                "end_line": 52,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 28,
+                                                "start_line": 52
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 15,
+                                        "start_line": 13
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 51
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 13
+                    }
+                },
+                "164": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 41,
+                                "end_line": 51,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 63,
+                                        "end_line": 13,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 51,
+                                                "end_line": 52,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 28,
+                                                "start_line": 52
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 36,
+                                        "start_line": 13
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 51
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 13
+                    }
+                },
+                "165": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 41,
+                                "end_line": 51,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 80,
+                                        "end_line": 13,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 51,
+                                                "end_line": 52,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 28,
+                                                "start_line": 52
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 65,
+                                        "start_line": 13
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 30,
+                                "start_line": 51
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 13
+                    }
+                },
+                "166": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 51,
+                        "end_line": 52,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 28,
+                        "start_line": 52
+                    }
+                },
+                "168": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 27,
+                        "end_line": 50,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 57,
+                                "end_line": 57,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 44,
+                                "start_line": 57
+                            },
+                            "While expanding the reference 'admin_address' in:"
+                        ],
+                        "start_col": 7,
+                        "start_line": 50
+                    }
+                },
+                "169": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 67,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 34,
+                        "start_line": 57
+                    }
+                },
+                "171": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 67,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 34,
+                        "start_line": 57
+                    }
+                },
+                "173": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 34,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 52,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 32,
+                                        "end_line": 153,
+                                        "input_file": {
+                                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 10,
+                                                "end_line": 58,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 34,
+                                                "start_line": 53
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 13,
+                                        "start_line": 153
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 28,
+                                "start_line": 52
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 15,
+                        "start_line": 13
+                    }
+                },
+                "174": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 24,
+                        "end_line": 52,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 34,
+                                "end_line": 54,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 24,
+                                "start_line": 54
+                            },
+                            "While expanding the reference 'class_hash' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 52
+                    }
+                },
+                "175": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 26,
+                        "end_line": 51,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 47,
+                                "end_line": 55,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 35,
+                                "start_line": 55
+                            },
+                            "While expanding the reference 'current_salt' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 51
+                    }
+                },
+                "176": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 40,
+                        "end_line": 56,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 39,
+                        "start_line": 56
+                    }
+                },
+                "178": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 67,
+                        "end_line": 57,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 34,
+                        "start_line": 57
+                    }
+                },
+                "179": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 10,
+                        "end_line": 58,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 34,
+                        "start_line": 53
+                    }
+                },
+                "181": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 32,
+                        "end_line": 153,
+                        "input_file": {
+                            "filename": "/home/cashack/cairo_venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 10,
+                                "end_line": 58,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 35,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 43,
+                                                "end_line": 59,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 59
+                                            },
+                                            "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 16,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 34,
+                                "start_line": 53
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 13,
+                        "start_line": 153
+                    }
+                },
+                "182": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 63,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 52,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 64,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 43,
+                                                "end_line": 59,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 59
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 37,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 28,
+                                "start_line": 52
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 36,
+                        "start_line": 13
+                    }
+                },
+                "183": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 80,
+                        "end_line": 13,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/admin_class_hash/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 51,
+                                "end_line": 52,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 81,
+                                        "end_line": 21,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 43,
+                                                "end_line": 59,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 59
+                                            },
+                                            "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 66,
+                                        "start_line": 21
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 28,
+                                "start_line": 52
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 65,
+                        "start_line": 13
+                    }
+                },
+                "184": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 42,
+                        "end_line": 59,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 26,
+                        "start_line": 59
+                    }
+                },
+                "186": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 43,
+                        "end_line": 59,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 59
+                    }
+                },
+                "188": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 35,
+                        "end_line": 21,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 43,
+                                "end_line": 59,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 30,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 36,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 10,
+                                                        "end_line": 63,
+                                                        "input_file": {
+                                                            "filename": "game_factory.cairo"
+                                                        },
+                                                        "start_col": 9,
+                                                        "start_line": 61
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 11,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 9,
+                                "start_line": 59
+                            },
+                            "While trying to update the implicit return value 'syscall_ptr' in:"
+                        ],
+                        "start_col": 16,
+                        "start_line": 21
+                    }
+                },
+                "189": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 81,
+                        "end_line": 21,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 43,
+                                "end_line": 59,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 47,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 36,
+                                                "end_line": 24,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 10,
+                                                        "end_line": 63,
+                                                        "input_file": {
+                                                            "filename": "game_factory.cairo"
+                                                        },
+                                                        "start_col": 9,
+                                                        "start_line": 61
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 24
+                                            },
+                                            "While handling event:"
+                                        ],
+                                        "start_col": 32,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 9,
+                                "start_line": 59
+                            },
+                            "While trying to update the implicit return value 'range_check_ptr' in:"
+                        ],
+                        "start_col": 66,
+                        "start_line": 21
+                    }
+                },
+                "190": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 53,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 46,
+                                "end_line": 62,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 30,
+                                "start_line": 62
+                            },
+                            "While expanding the reference 'contract_address' in:"
+                        ],
+                        "start_col": 14,
+                        "start_line": 53
+                    }
+                },
+                "191": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 10,
+                        "end_line": 63,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 61
+                    }
+                },
+                "193": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 30,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 10,
+                                        "end_line": 63,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 24,
+                                                "end_line": 47,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 18,
+                                                        "end_line": 64,
+                                                        "input_file": {
+                                                            "filename": "game_factory.cairo"
+                                                        },
+                                                        "start_col": 9,
+                                                        "start_line": 64
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                                                ],
+                                                "start_col": 5,
+                                                "start_line": 47
+                                            },
+                                            "While expanding the reference 'syscall_ptr' in:"
+                                        ],
+                                        "start_col": 9,
+                                        "start_line": 61
+                                    },
+                                    "While trying to update the implicit return value 'syscall_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 11,
+                        "start_line": 1
+                    }
+                },
+                "194": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 21,
+                        "input_file": {
+                            "filename": "autogen/starknet/storage_var/salt/decl.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 43,
+                                "end_line": 59,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 32,
+                                        "end_line": 48,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 18,
+                                                "end_line": 64,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 9,
+                                                "start_line": 64
+                                            },
+                                            "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                                        ],
+                                        "start_col": 5,
+                                        "start_line": 48
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 9,
+                                "start_line": 59
+                            },
+                            "While trying to update the implicit return value 'pedersen_ptr' in:"
+                        ],
+                        "start_col": 37,
+                        "start_line": 21
+                    }
+                },
+                "195": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 47,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/event/administered_contract_deployed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 36,
+                                "end_line": 24,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 10,
+                                        "end_line": 63,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 20,
+                                                "end_line": 49,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 18,
+                                                        "end_line": 64,
+                                                        "input_file": {
+                                                            "filename": "game_factory.cairo"
+                                                        },
+                                                        "start_col": 9,
+                                                        "start_line": 64
+                                                    },
+                                                    "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                                ],
+                                                "start_col": 5,
+                                                "start_line": 49
+                                            },
+                                            "While expanding the reference 'range_check_ptr' in:"
+                                        ],
+                                        "start_col": 9,
+                                        "start_line": 61
+                                    },
+                                    "While trying to update the implicit return value 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 24
+                            },
+                            "While handling event:"
+                        ],
+                        "start_col": 32,
+                        "start_line": 1
+                    }
+                },
+                "196": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__main__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 18,
+                        "end_line": 64,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 64
+                    }
+                },
+                "197": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 40,
+                        "end_line": 2,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/c8f8e2249de7b41049de03cb248003121a3f9d075aa868b48f0168d146fac255.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 27,
+                                "end_line": 50,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 45,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "parent_location": [
+                                                    {
+                                                        "end_col": 57,
+                                                        "end_line": 1,
+                                                        "input_file": {
+                                                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                                                        },
+                                                        "parent_location": [
+                                                            {
+                                                                "end_col": 21,
+                                                                "end_line": 46,
+                                                                "input_file": {
+                                                                    "filename": "game_factory.cairo"
+                                                                },
+                                                                "start_col": 6,
+                                                                "start_line": 46
+                                                            },
+                                                            "While handling calldata of"
+                                                        ],
+                                                        "start_col": 35,
+                                                        "start_line": 1
+                                                    },
+                                                    "While expanding the reference '__calldata_actual_size' in:"
+                                                ],
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While handling calldata of"
+                                        ],
+                                        "start_col": 31,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_ptr' in:"
+                                ],
+                                "start_col": 7,
+                                "start_line": 50
+                            },
+                            "While handling calldata argument 'admin_address'"
+                        ],
+                        "start_col": 22,
+                        "start_line": 2
+                    }
+                },
+                "199": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 57,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While handling calldata of"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                },
+                "200": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 64,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 24,
+                                "end_line": 47,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 55,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 44,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 47
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 19,
+                        "start_line": 1
+                    }
+                },
+                "201": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 110,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 32,
+                                "end_line": 48,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 82,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 70,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 48
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 20,
+                        "start_line": 1
+                    }
+                },
+                "202": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 67,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 20,
+                                "end_line": 49,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 115,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 100,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 5,
+                                "start_line": 49
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 23,
+                        "start_line": 1
+                    }
+                },
+                "203": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 52,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/arg_processor/c8f8e2249de7b41049de03cb248003121a3f9d075aa868b48f0168d146fac255.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 27,
+                                "end_line": 50,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 159,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 131,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference '__calldata_arg_admin_address' in:"
+                                ],
+                                "start_col": 7,
+                                "start_line": 50
+                            },
+                            "While handling calldata argument 'admin_address'"
+                        ],
+                        "start_col": 36,
+                        "start_line": 1
+                    }
+                },
+                "204": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 21,
+                        "end_line": 46,
+                        "input_file": {
+                            "filename": "game_factory.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 46
+                    }
+                },
+                "206": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [
+                        {
+                            "location": {
+                                "end_col": 34,
+                                "end_line": 2,
+                                "input_file": {
+                                    "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 21,
+                                        "end_line": 46,
+                                        "input_file": {
+                                            "filename": "game_factory.cairo"
+                                        },
+                                        "start_col": 6,
+                                        "start_line": 46
+                                    },
+                                    "While constructing the external wrapper for:"
+                                ],
+                                "start_col": 1,
+                                "start_line": 2
+                            },
+                            "n_prefix_newlines": 0
+                        }
+                    ],
+                    "inst": {
+                        "end_col": 24,
+                        "end_line": 3,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 3
+                    }
+                },
+                "208": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 55,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 20,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 9,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'syscall_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 44,
+                        "start_line": 1
+                    }
+                },
+                "209": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 82,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 33,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 21,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'pedersen_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 70,
+                        "start_line": 1
+                    }
+                },
+                "210": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 115,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 49,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 34,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'range_check_ptr' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 100,
+                        "start_line": 1
+                    }
+                },
+                "211": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 21,
+                        "end_line": 4,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 62,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 50,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'retdata_size' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 20,
+                        "start_line": 4
+                    }
+                },
+                "213": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 16,
+                        "end_line": 3,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/028fda3345f9efdcff91bf445a3e7af24894a0e2467ae8f5e148bfb03ab79fa7.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "parent_location": [
+                                    {
+                                        "end_col": 70,
+                                        "end_line": 1,
+                                        "input_file": {
+                                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                        },
+                                        "parent_location": [
+                                            {
+                                                "end_col": 21,
+                                                "end_line": 46,
+                                                "input_file": {
+                                                    "filename": "game_factory.cairo"
+                                                },
+                                                "start_col": 6,
+                                                "start_line": 46
+                                            },
+                                            "While constructing the external wrapper for:"
+                                        ],
+                                        "start_col": 63,
+                                        "start_line": 1
+                                    },
+                                    "While expanding the reference 'retdata' in:"
+                                ],
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 9,
+                        "start_line": 3
+                    }
+                },
+                "214": {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "flow_tracking_data": null,
+                    "hints": [],
+                    "inst": {
+                        "end_col": 71,
+                        "end_line": 1,
+                        "input_file": {
+                            "filename": "autogen/starknet/external/deploy_new_game/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                        },
+                        "parent_location": [
+                            {
+                                "end_col": 21,
+                                "end_line": 46,
+                                "input_file": {
+                                    "filename": "game_factory.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 46
+                            },
+                            "While constructing the external wrapper for:"
+                        ],
+                        "start_col": 1,
+                        "start_line": 1
+                    }
+                }
+            }
+        },
+        "hints": {
+            "0": [
+                {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.alloc",
+                        "starkware.cairo.common.alloc.alloc"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 0,
+                            "offset": 0
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "19": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.deploy"
+                    ],
+                    "code": "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 3,
+                            "offset": 2
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.deploy.syscall_ptr": 0
+                        }
+                    }
+                }
+            ],
+            "27": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "code": "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 4,
+                            "offset": 1
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.storage_read.syscall_ptr": 1
+                        }
+                    }
+                }
+            ],
+            "36": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "code": "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 5,
+                            "offset": 1
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.storage_write.syscall_ptr": 2
+                        }
+                    }
+                }
+            ],
+            "46": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "code": "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 6,
+                            "offset": 1
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.emit_event.syscall_ptr": 3
+                        }
+                    }
+                }
+            ],
+            "149": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 15,
+                            "offset": 29
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "206": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.deploy_new_game"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 17,
+                            "offset": 121
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ]
+        },
+        "identifiers": {
+            "__main__.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.admin_class_hash": {
+                "type": "namespace"
+            },
+            "__main__.admin_class_hash.Args": {
+                "full_name": "__main__.admin_class_hash.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.admin_class_hash.ImplicitArgs": {
+                "full_name": "__main__.admin_class_hash.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.admin_class_hash.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.admin_class_hash.addr": {
+                "decorators": [],
+                "pc": 79,
+                "type": "function"
+            },
+            "__main__.admin_class_hash.addr.Args": {
+                "full_name": "__main__.admin_class_hash.addr.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.addr.ImplicitArgs": {
+                "full_name": "__main__.admin_class_hash.addr.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 0
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.addr.Return": {
+                "cairo_type": "(res : felt)",
+                "type": "type_definition"
+            },
+            "__main__.admin_class_hash.addr.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.admin_class_hash.hash2": {
+                "destination": "starkware.cairo.common.hash.hash2",
+                "type": "alias"
+            },
+            "__main__.admin_class_hash.normalize_address": {
+                "destination": "starkware.starknet.common.storage.normalize_address",
+                "type": "alias"
+            },
+            "__main__.admin_class_hash.read": {
+                "decorators": [],
+                "pc": 84,
+                "type": "function"
+            },
+            "__main__.admin_class_hash.read.Args": {
+                "full_name": "__main__.admin_class_hash.read.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.read.ImplicitArgs": {
+                "full_name": "__main__.admin_class_hash.read.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.read.Return": {
+                "cairo_type": "(value : felt)",
+                "type": "type_definition"
+            },
+            "__main__.admin_class_hash.read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.admin_class_hash.storage_read": {
+                "destination": "starkware.starknet.common.syscalls.storage_read",
+                "type": "alias"
+            },
+            "__main__.admin_class_hash.storage_write": {
+                "destination": "starkware.starknet.common.syscalls.storage_write",
+                "type": "alias"
+            },
+            "__main__.admin_class_hash.write": {
+                "decorators": [],
+                "pc": 97,
+                "type": "function"
+            },
+            "__main__.admin_class_hash.write.Args": {
+                "full_name": "__main__.admin_class_hash.write.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.write.ImplicitArgs": {
+                "full_name": "__main__.admin_class_hash.write.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.admin_class_hash.write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.admin_class_hash.write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.administered_contract_deployed": {
+                "type": "namespace"
+            },
+            "__main__.administered_contract_deployed.Args": {
+                "full_name": "__main__.administered_contract_deployed.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.administered_contract_deployed.ImplicitArgs": {
+                "full_name": "__main__.administered_contract_deployed.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.administered_contract_deployed.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.administered_contract_deployed.SELECTOR": {
+                "type": "const",
+                "value": 1113456095628711595141581491376614336579541492271305367068240177673059219309
+            },
+            "__main__.administered_contract_deployed.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.administered_contract_deployed.alloc": {
+                "destination": "starkware.cairo.common.alloc.alloc",
+                "type": "alias"
+            },
+            "__main__.administered_contract_deployed.emit": {
+                "decorators": [],
+                "pc": 109,
+                "type": "function"
+            },
+            "__main__.administered_contract_deployed.emit.Args": {
+                "full_name": "__main__.administered_contract_deployed.emit.Args",
+                "members": {
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.administered_contract_deployed.emit.ImplicitArgs": {
+                "full_name": "__main__.administered_contract_deployed.emit.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.administered_contract_deployed.emit.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.administered_contract_deployed.emit.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__main__.administered_contract_deployed.emit_event": {
+                "destination": "starkware.starknet.common.syscalls.emit_event",
+                "type": "alias"
+            },
+            "__main__.administered_contract_deployed.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__main__.alloc": {
+                "destination": "starkware.cairo.common.alloc.alloc",
+                "type": "alias"
+            },
+            "__main__.constructor": {
+                "decorators": [
+                    "constructor"
+                ],
+                "pc": 133,
+                "type": "function"
+            },
+            "__main__.constructor.Args": {
+                "full_name": "__main__.constructor.Args",
+                "members": {
+                    "admin_class_hash_": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.constructor.ImplicitArgs": {
+                "full_name": "__main__.constructor.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.constructor.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.constructor.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.deploy": {
+                "destination": "starkware.starknet.common.syscalls.deploy",
+                "type": "alias"
+            },
+            "__main__.deploy_new_game": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 158,
+                "type": "function"
+            },
+            "__main__.deploy_new_game.Args": {
+                "full_name": "__main__.deploy_new_game.Args",
+                "members": {
+                    "admin_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.deploy_new_game.ImplicitArgs": {
+                "full_name": "__main__.deploy_new_game.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.deploy_new_game.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.deploy_new_game.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.salt": {
+                "type": "namespace"
+            },
+            "__main__.salt.Args": {
+                "full_name": "__main__.salt.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.salt.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.salt.ImplicitArgs": {
+                "full_name": "__main__.salt.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.salt.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.salt.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.salt.addr": {
+                "decorators": [],
+                "pc": 49,
+                "type": "function"
+            },
+            "__main__.salt.addr.Args": {
+                "full_name": "__main__.salt.addr.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.salt.addr.ImplicitArgs": {
+                "full_name": "__main__.salt.addr.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 0
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.salt.addr.Return": {
+                "cairo_type": "(res : felt)",
+                "type": "type_definition"
+            },
+            "__main__.salt.addr.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.salt.hash2": {
+                "destination": "starkware.cairo.common.hash.hash2",
+                "type": "alias"
+            },
+            "__main__.salt.normalize_address": {
+                "destination": "starkware.starknet.common.storage.normalize_address",
+                "type": "alias"
+            },
+            "__main__.salt.read": {
+                "decorators": [],
+                "pc": 54,
+                "type": "function"
+            },
+            "__main__.salt.read.Args": {
+                "full_name": "__main__.salt.read.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.salt.read.ImplicitArgs": {
+                "full_name": "__main__.salt.read.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.salt.read.Return": {
+                "cairo_type": "(value : felt)",
+                "type": "type_definition"
+            },
+            "__main__.salt.read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.salt.storage_read": {
+                "destination": "starkware.starknet.common.syscalls.storage_read",
+                "type": "alias"
+            },
+            "__main__.salt.storage_write": {
+                "destination": "starkware.starknet.common.syscalls.storage_write",
+                "type": "alias"
+            },
+            "__main__.salt.write": {
+                "decorators": [],
+                "pc": 67,
+                "type": "function"
+            },
+            "__main__.salt.write.Args": {
+                "full_name": "__main__.salt.write.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.salt.write.ImplicitArgs": {
+                "full_name": "__main__.salt.write.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.salt.write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.salt.write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.constructor": {
+                "decorators": [
+                    "constructor"
+                ],
+                "pc": 140,
+                "type": "function"
+            },
+            "__wrappers__.constructor.Args": {
+                "full_name": "__wrappers__.constructor.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.constructor.ImplicitArgs": {
+                "full_name": "__wrappers__.constructor.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.constructor.Return": {
+                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.constructor.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.constructor.__wrapped_func": {
+                "destination": "__main__.constructor",
+                "type": "alias"
+            },
+            "__wrappers__.constructor_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.deploy_new_game": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 197,
+                "type": "function"
+            },
+            "__wrappers__.deploy_new_game.Args": {
+                "full_name": "__wrappers__.deploy_new_game.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.deploy_new_game.ImplicitArgs": {
+                "full_name": "__wrappers__.deploy_new_game.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.deploy_new_game.Return": {
+                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.deploy_new_game.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.deploy_new_game.__wrapped_func": {
+                "destination": "__main__.deploy_new_game",
+                "type": "alias"
+            },
+            "__wrappers__.deploy_new_game_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "starkware.cairo.common.alloc.alloc": {
+                "decorators": [],
+                "pc": 0,
+                "type": "function"
+            },
+            "starkware.cairo.common.alloc.alloc.Args": {
+                "full_name": "starkware.cairo.common.alloc.alloc.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.common.alloc.alloc.ImplicitArgs": {
+                "full_name": "starkware.cairo.common.alloc.alloc.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.common.alloc.alloc.Return": {
+                "cairo_type": "(ptr : felt*)",
+                "type": "type_definition"
+            },
+            "starkware.cairo.common.alloc.alloc.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+                "members": {
+                    "x": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "x_and_y": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "x_or_y": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "x_xor_y": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "y": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+                "members": {
+                    "m": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "p": {
+                        "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                        "offset": 0
+                    },
+                    "q": {
+                        "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                        "offset": 2
+                    },
+                    "r": {
+                        "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                        "offset": 5
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.EcPoint": {
+                "destination": "starkware.cairo.common.ec_point.EcPoint",
+                "type": "alias"
+            },
+            "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "members": {
+                    "result": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "x": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "y": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+                "members": {
+                    "message": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "pub_key": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.dict_access.DictAccess": {
+                "full_name": "starkware.cairo.common.dict_access.DictAccess",
+                "members": {
+                    "key": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "new_value": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "prev_value": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.cairo.common.ec_point.EcPoint": {
+                "full_name": "starkware.cairo.common.ec_point.EcPoint",
+                "members": {
+                    "x": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "y": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.hash.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_ap": {
+                "decorators": [
+                    "known_ap_change"
+                ],
+                "pc": 4,
+                "type": "function"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_ap.Args": {
+                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_ap.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_ap.ImplicitArgs": {
+                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_ap.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_ap.Return": {
+                "cairo_type": "(ap_val : felt*)",
+                "type": "type_definition"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_ap.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc": {
+                "decorators": [],
+                "pc": 3,
+                "type": "function"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Args": {
+                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.ImplicitArgs": {
+                "full_name": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Return": {
+                "cairo_type": "(fp_val : felt*, pc_val : felt*)",
+                "type": "type_definition"
+            },
+            "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.storage.ADDR_BOUND": {
+                "type": "const",
+                "value": -106710729501573572985208420194530329073740042555888586719489
+            },
+            "starkware.starknet.common.storage.MAX_STORAGE_ITEM_SIZE": {
+                "type": "const",
+                "value": 256
+            },
+            "starkware.starknet.common.storage.assert_250_bit": {
+                "destination": "starkware.cairo.common.math.assert_250_bit",
+                "type": "alias"
+            },
+            "starkware.starknet.common.syscalls.CALL_CONTRACT_SELECTOR": {
+                "type": "const",
+                "value": 20853273475220472486191784820
+            },
+            "starkware.starknet.common.syscalls.CallContract": {
+                "full_name": "starkware.starknet.common.syscalls.CallContract",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.CallContractRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+                        "offset": 5
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.CallContractRequest": {
+                "full_name": "starkware.starknet.common.syscalls.CallContractRequest",
+                "members": {
+                    "calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "function_selector": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.CallContractResponse": {
+                "full_name": "starkware.starknet.common.syscalls.CallContractResponse",
+                "members": {
+                    "retdata": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "retdata_size": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DELEGATE_CALL_SELECTOR": {
+                "type": "const",
+                "value": 21167594061783206823196716140
+            },
+            "starkware.starknet.common.syscalls.DELEGATE_L1_HANDLER_SELECTOR": {
+                "type": "const",
+                "value": 23274015802972845247556842986379118667122
+            },
+            "starkware.starknet.common.syscalls.DEPLOY_SELECTOR": {
+                "type": "const",
+                "value": 75202468540281
+            },
+            "starkware.starknet.common.syscalls.Deploy": {
+                "full_name": "starkware.starknet.common.syscalls.Deploy",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.DeployRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.DeployResponse",
+                        "offset": 6
+                    }
+                },
+                "size": 9,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DeployRequest": {
+                "full_name": "starkware.starknet.common.syscalls.DeployRequest",
+                "members": {
+                    "class_hash": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "constructor_calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "constructor_calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "contract_address_salt": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "reserved": {
+                        "cairo_type": "felt",
+                        "offset": 5
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 6,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DeployResponse": {
+                "full_name": "starkware.starknet.common.syscalls.DeployResponse",
+                "members": {
+                    "constructor_retdata": {
+                        "cairo_type": "felt*",
+                        "offset": 2
+                    },
+                    "constructor_retdata_size": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DictAccess": {
+                "destination": "starkware.cairo.common.dict_access.DictAccess",
+                "type": "alias"
+            },
+            "starkware.starknet.common.syscalls.EMIT_EVENT_SELECTOR": {
+                "type": "const",
+                "value": 1280709301550335749748
+            },
+            "starkware.starknet.common.syscalls.EmitEvent": {
+                "full_name": "starkware.starknet.common.syscalls.EmitEvent",
+                "members": {
+                    "data": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "data_len": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "keys": {
+                        "cairo_type": "felt*",
+                        "offset": 2
+                    },
+                    "keys_len": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GET_BLOCK_NUMBER_SELECTOR": {
+                "type": "const",
+                "value": 1448089106835523001438702345020786
+            },
+            "starkware.starknet.common.syscalls.GET_BLOCK_TIMESTAMP_SELECTOR": {
+                "type": "const",
+                "value": 24294903732626645868215235778792757751152
+            },
+            "starkware.starknet.common.syscalls.GET_CALLER_ADDRESS_SELECTOR": {
+                "type": "const",
+                "value": 94901967781393078444254803017658102643
+            },
+            "starkware.starknet.common.syscalls.GET_CONTRACT_ADDRESS_SELECTOR": {
+                "type": "const",
+                "value": 6219495360805491471215297013070624192820083
+            },
+            "starkware.starknet.common.syscalls.GET_SEQUENCER_ADDRESS_SELECTOR": {
+                "type": "const",
+                "value": 1592190833581991703053805829594610833820054387
+            },
+            "starkware.starknet.common.syscalls.GET_TX_INFO_SELECTOR": {
+                "type": "const",
+                "value": 1317029390204112103023
+            },
+            "starkware.starknet.common.syscalls.GET_TX_SIGNATURE_SELECTOR": {
+                "type": "const",
+                "value": 1448089128652340074717162277007973
+            },
+            "starkware.starknet.common.syscalls.GetBlockNumber": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockNumber",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockNumberRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockNumberResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+                "members": {
+                    "block_number": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockTimestamp": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockTimestamp",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockTimestampRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockTimestampResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+                "members": {
+                    "block_timestamp": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetCallerAddress": {
+                "full_name": "starkware.starknet.common.syscalls.GetCallerAddress",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetCallerAddressRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetCallerAddressResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+                "members": {
+                    "caller_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetContractAddress": {
+                "full_name": "starkware.starknet.common.syscalls.GetContractAddress",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetContractAddressRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetContractAddressResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+                "members": {
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetSequencerAddress": {
+                "full_name": "starkware.starknet.common.syscalls.GetSequencerAddress",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetSequencerAddressRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetSequencerAddressResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+                "members": {
+                    "sequencer_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxInfo": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxInfo",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxInfoRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxInfoResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+                "members": {
+                    "tx_info": {
+                        "cairo_type": "starkware.starknet.common.syscalls.TxInfo*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxSignature": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxSignature",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxSignatureRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxSignatureResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+                "members": {
+                    "signature": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "signature_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.LIBRARY_CALL_L1_HANDLER_SELECTOR": {
+                "type": "const",
+                "value": 436233452754198157705746250789557519228244616562
+            },
+            "starkware.starknet.common.syscalls.LIBRARY_CALL_SELECTOR": {
+                "type": "const",
+                "value": 92376026794327011772951660
+            },
+            "starkware.starknet.common.syscalls.LibraryCall": {
+                "full_name": "starkware.starknet.common.syscalls.LibraryCall",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.LibraryCallRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+                        "offset": 5
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.LibraryCallRequest": {
+                "full_name": "starkware.starknet.common.syscalls.LibraryCallRequest",
+                "members": {
+                    "calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "class_hash": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "function_selector": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.SEND_MESSAGE_TO_L1_SELECTOR": {
+                "type": "const",
+                "value": 433017908768303439907196859243777073
+            },
+            "starkware.starknet.common.syscalls.STORAGE_READ_SELECTOR": {
+                "type": "const",
+                "value": 100890693370601760042082660
+            },
+            "starkware.starknet.common.syscalls.STORAGE_WRITE_SELECTOR": {
+                "type": "const",
+                "value": 25828017502874050592466629733
+            },
+            "starkware.starknet.common.syscalls.SendMessageToL1SysCall": {
+                "full_name": "starkware.starknet.common.syscalls.SendMessageToL1SysCall",
+                "members": {
+                    "payload_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 3
+                    },
+                    "payload_size": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "to_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 4,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageRead": {
+                "full_name": "starkware.starknet.common.syscalls.StorageRead",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.StorageReadRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageReadRequest": {
+                "full_name": "starkware.starknet.common.syscalls.StorageReadRequest",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageReadResponse": {
+                "full_name": "starkware.starknet.common.syscalls.StorageReadResponse",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageWrite": {
+                "full_name": "starkware.starknet.common.syscalls.StorageWrite",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.TxInfo": {
+                "full_name": "starkware.starknet.common.syscalls.TxInfo",
+                "members": {
+                    "account_contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "chain_id": {
+                        "cairo_type": "felt",
+                        "offset": 6
+                    },
+                    "max_fee": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "signature": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "signature_len": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "transaction_hash": {
+                        "cairo_type": "felt",
+                        "offset": 5
+                    },
+                    "version": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.deploy": {
+                "decorators": [],
+                "pc": 9,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.deploy.Args": {
+                "full_name": "starkware.starknet.common.syscalls.deploy.Args",
+                "members": {
+                    "class_hash": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "constructor_calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 3
+                    },
+                    "constructor_calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "contract_address_salt": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 4,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.deploy.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.deploy.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.deploy.Return": {
+                "cairo_type": "(contract_address : felt)",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.deploy.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.deploy.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.deploy.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 3,
+                            "offset": 0
+                        },
+                        "pc": 9,
+                        "value": "[cast(fp + (-7), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 3,
+                            "offset": 2
+                        },
+                        "pc": 19,
+                        "value": "cast([fp + (-7)] + 9, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.emit_event": {
+                "decorators": [],
+                "pc": 39,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.emit_event.Args": {
+                "full_name": "starkware.starknet.common.syscalls.emit_event.Args",
+                "members": {
+                    "data": {
+                        "cairo_type": "felt*",
+                        "offset": 3
+                    },
+                    "data_len": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "keys": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "keys_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 4,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.emit_event.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.emit_event.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.emit_event.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.emit_event.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.emit_event.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.emit_event.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 6,
+                            "offset": 0
+                        },
+                        "pc": 39,
+                        "value": "[cast(fp + (-7), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 6,
+                            "offset": 1
+                        },
+                        "pc": 46,
+                        "value": "cast([fp + (-7)] + 5, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_read": {
+                "decorators": [],
+                "pc": 23,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.storage_read.Args": {
+                "full_name": "starkware.starknet.common.syscalls.storage_read.Args",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_read.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.storage_read.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_read.Return": {
+                "cairo_type": "(value : felt)",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.storage_read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.storage_read.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.storage_read.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 0
+                        },
+                        "pc": 23,
+                        "value": "[cast(fp + (-4), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 1
+                        },
+                        "pc": 27,
+                        "value": "cast([fp + (-4)] + 3, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_write": {
+                "decorators": [],
+                "pc": 31,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.storage_write.Args": {
+                "full_name": "starkware.starknet.common.syscalls.storage_write.Args",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_write.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.storage_write.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.storage_write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.storage_write.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.storage_write.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 0
+                        },
+                        "pc": 31,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 1
+                        },
+                        "pc": 36,
+                        "value": "cast([fp + (-5)] + 3, felt*)"
+                    }
+                ],
+                "type": "reference"
+            }
+        },
+        "main_scope": "__main__",
+        "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+        "reference_manager": {
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 9,
+                    "value": "[cast(fp + (-7), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 23,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 31,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 39,
+                    "value": "[cast(fp + (-7), felt**)]"
+                }
+            ]
+        }
+    }
+}

--- a/contracts/turn_logger/struct.cairo
+++ b/contracts/turn_logger/struct.cairo
@@ -1,0 +1,2 @@
+%lang starknet
+

--- a/contracts/turn_logger/struct.cairo
+++ b/contracts/turn_logger/struct.cairo
@@ -1,2 +1,0 @@
-%lang starknet
-

--- a/contracts/turn_logger/structs.cairo
+++ b/contracts/turn_logger/structs.cairo
@@ -1,0 +1,14 @@
+%lang starknet
+
+struct Player:
+    member address_id : felt
+    member role : felt
+    member is_dead : felt
+end
+
+struct Game:
+    member players_len : felt
+    member players : Player*
+    member is_ended : felt
+    member index : felt
+end

--- a/contracts/turn_logger/turn_logger.cairo
+++ b/contracts/turn_logger/turn_logger.cairo
@@ -1,7 +1,9 @@
 %lang starknet
 
 from starkware.starknet.common.syscalls import get_caller_address, get_block_timestamp
+from starkware.cairo.common.cairo_builtins import HashBuiltin
 
+from structs import Player
 # This should work on validating rounds and saying who died each day
 
 # Assign roles, or don't? Figure out who won?
@@ -36,7 +38,7 @@ end
 #
 
 @storage_var
-func character_will_storage(address : felt) -> (will : WillStruct):
+func character_storage(address : felt) -> (character : Player):
 end
 
 ##require a with attr asser that caller sender is the person will holder
@@ -68,6 +70,8 @@ end
 #
 # Setters; set the key 
 #
+@external
+func set_new_player{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 
 
 #


### PR DESCRIPTION
An aside, but seems that the structure of these contracts/ the entire game is not so much about permissionless-ness, as making the backend easier to manage by hosting on chain. Resolution by an admin account makes it semi centralized to the frontend rn. 

In a future rendition, would be interested in making this as peer hosted and organized as possible, but seems to be an open problem in blockchain games, which require a neutral game master that gets lost with verifiable computation versus consensus level app-chain dev.